### PR TITLE
feat(mini-monitor): show service registration + build status rows

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -108,6 +108,8 @@
     .row .v.accent { color: var(--accent); }
     .row .v.err    { color: var(--err); }
     .row .v.ok     { color: var(--ok); }
+    .row .v.warn   { color: var(--warn); }
+    .row .v.muted  { color: var(--muted); }
     .workers-mini { font-size: 11px; color: var(--muted); max-height: 60px; overflow-y: auto; }
     .workers-mini .w { display: inline-block; margin-right: 6px; padding: 1px 6px;
       background: #14243d; color: var(--accent); border-radius: 8px; }
@@ -175,6 +177,14 @@
       </div>
     </div>
     <div class="rows">
+      <!-- High-priority operator-facing status — at the very top so it's the
+           first thing the eye lands on after the header. "サービス" tells
+           the operator whether the daemon is the NSSM-registered Windows
+           service (production deploy) or a manually-launched venv process
+           (dev mode); "ビルド" tells them whether RAG indexing is live,
+           paused on purpose, or just idle (no work to do). -->
+      <div class="row"><span class="k">サービス</span><span class="v" id="service-status">-</span></div>
+      <div class="row"><span class="k">ビルド</span><span class="v" id="build-status">-</span></div>
       <div class="row"><span class="k">PG / Drive</span><span class="v" id="conns">- / -</span></div>
       <div class="row"><span class="k">FDs enabled</span><span class="v" id="fds">-/-</span></div>
       <div class="row"><span class="k">Files</span><span class="v accent" id="files">-</span></div>

--- a/desktop/renderer.js
+++ b/desktop/renderer.js
@@ -269,6 +269,51 @@ async function tick() {
     }
 
     // --- rows
+    // Service registration row — most important operator-facing status.
+    // Tells the operator at a glance whether the running daemon is the
+    // production NSSM-registered Windows service or an ad-hoc venv-
+    // launched dev process. /api/stats.service_managed_by ∈
+    // {"nssm","partial","manual"} based on `sc query` results for
+    // WinServerRAG-API and WinServerRAG-Daemon.
+    const svcEl = $("service-status");
+    const managed = s.service_managed_by;
+    if (managed === "nssm") {
+      svcEl.textContent = "● 登録済 (NSSM)";
+      svcEl.className = "v ok";
+    } else if (managed === "partial") {
+      // Exactly one service registered — usually means a half-uninstall
+      // or a manual NSSM tweak. Worth flagging so the operator notices.
+      svcEl.textContent = "▲ 一部登録 (要確認)";
+      svcEl.className = "v warn";
+    } else {
+      // "manual" or undefined — venv-launched dev mode is normal here.
+      svcEl.textContent = "○ 未登録 (手動起動)";
+      svcEl.className = "v muted";
+    }
+
+    // Build status row — explicit text label for indexing state. Mirrors
+    // the indicator color logic but spells it out so a glance at the row
+    // alone tells you "実行中" / "停止中" / "アイドル" without having to
+    // decode an indicator dot. Priority matches setIndicator() above:
+    //   error/dead daemon → 障害
+    //   paused=true       → 停止中（手動停止）
+    //   activeWorkers > 0 → 実行中 (N workers)
+    //   else              → アイドル
+    const buildEl = $("build-status");
+    if (daemonLooksDead || anyErr) {
+      buildEl.textContent = "✕ 障害 (詳細はログ)";
+      buildEl.className = "v err";
+    } else if (s.paused) {
+      buildEl.textContent = "⏸ 停止中（手動停止）";
+      buildEl.className = "v muted";
+    } else if (activeWorkers.length > 0) {
+      buildEl.textContent = `⚙ 実行中 (${activeWorkers.length} workers)`;
+      buildEl.className = "v ok";
+    } else {
+      buildEl.textContent = "💤 アイドル";
+      buildEl.className = "v";
+    }
+
     const pgVal = s.pg_ok ? "PG" : "PG ×";
     const drvVal = s.drive_ok ? "Drive" : "Drive ×";
     const connsEl = $("conns");
@@ -411,6 +456,14 @@ function showErr() {
   $("files").textContent = "-";
   $("chunks").textContent = "-";
   $("dbsize").textContent = "-";
+  // Service / build status: API down means we can't tell either, so
+  // surface that honestly rather than freezing the last known good value.
+  const svcEl = $("service-status");
+  svcEl.textContent = "? (API 不通)";
+  svcEl.className = "v err";
+  const buildEl = $("build-status");
+  buildEl.textContent = "? (API 不通)";
+  buildEl.className = "v err";
   lastFilesDoneSum = 0;
 }
 

--- a/src/control_api.py
+++ b/src/control_api.py
@@ -128,6 +128,20 @@ async def _lifespan(_app):
         except Exception as e:
             log.error("startup mcp-user seed / pause bootstrap failed (non-fatal): %s", e)
 
+        # Bootstrap Windows service registration status into _stats_cache
+        # for the same reason. _stats_pump refreshes every 5s but the
+        # mini-monitor pulls /api/stats every 250ms, so the first 5s
+        # would otherwise show "未登録 (manual)" even on an NSSM-managed
+        # install.
+        try:
+            svc, managed_by = await asyncio.to_thread(_check_service_registration)
+            with _stats_lock:
+                _stats_cache["service_status"] = svc
+                _stats_cache["service_managed_by"] = managed_by
+            log.info("service registration: managed_by=%s", managed_by)
+        except Exception as e:
+            log.warning("startup service-status bootstrap failed (non-fatal): %s", e)
+
         # Fix C: prime the Google Drive service once at startup so requests
         # don't block on OAuth refresh. _get_service() now just returns the
         # cached handle.
@@ -532,6 +546,20 @@ _stats_cache: dict = {
     # via /api/stats and toggles the ⏸/▶ button accordingly.
     "paused": False,
     "paused_since": None,
+    # Windows service registration status. Populated by _stats_pump every
+    # 5s via `sc query`. Two services we care about: WinServerRAG-API and
+    # WinServerRAG-Daemon. Each entry is {registered: bool, running: bool}.
+    # When both registered + running, the operator deployed via the v1.2
+    # installer; otherwise they're running ad-hoc from a venv (dev mode).
+    "service_status": {
+        "WinServerRAG-API":    {"registered": False, "running": False},
+        "WinServerRAG-Daemon": {"registered": False, "running": False},
+    },
+    # Convenience derived field:
+    #   "nssm"    — both services registered via NSSM (production)
+    #   "partial" — exactly one service registered (broken install)
+    #   "manual"  — neither registered (dev mode, venv-launched)
+    "service_managed_by": "manual",
     # Device info (GPU vs CPU). Static fields are probed once at startup;
     # dynamic VRAM / util are refreshed in _stats_pump via nvidia-smi.
     "device": {
@@ -562,6 +590,49 @@ def _probe_device_static() -> dict:
         pass
     return {"kind": "cpu", "name": None, "total_vram_mb": None,
             "used_vram_mb": None, "util_pct": None, "power_w": None}
+
+
+def _check_service_registration() -> tuple[dict, str]:
+    """Probe WinServerRAG-API / WinServerRAG-Daemon Windows service status.
+
+    Uses `sc query <name>` which returns rc=0 + "STATE : RUNNING" line if
+    the service is registered AND running, rc=0 + "STATE : STOPPED" if
+    registered but down, and rc=1060 (1 here) if not registered.
+
+    Each call is bounded to 2 s so a hung Service Control Manager can't
+    stall the stats pump. On non-Windows hosts (CI Linux) sc.exe is
+    absent and we return all-false silently — the field is populated as
+    "manual" which matches the dev-mode reality on those platforms.
+
+    Returns (per-service dict, derived_managed_by_label).
+    """
+    import subprocess
+    services = ("WinServerRAG-API", "WinServerRAG-Daemon")
+    out = {}
+    for name in services:
+        registered = False
+        running = False
+        try:
+            r = subprocess.run(
+                ["sc", "query", name],
+                capture_output=True, text=True, timeout=2,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+            if r.returncode == 0:
+                registered = True
+                # `sc query` output line: "        STATE              : 4  RUNNING"
+                running = "RUNNING" in (r.stdout or "")
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            pass
+        out[name] = {"registered": registered, "running": running}
+    regs = sum(1 for v in out.values() if v["registered"])
+    if regs == len(services):
+        managed_by = "nssm"
+    elif regs == 0:
+        managed_by = "manual"
+    else:
+        managed_by = "partial"
+    return out, managed_by
 
 
 def _probe_gpu_live() -> dict | None:
@@ -619,6 +690,17 @@ async def _stats_pump():
             with _stats_lock:
                 _stats_cache["pg_ok"] = False
                 _stats_cache["last_updated"] = _time.time()
+
+        # Service registration check is OS-level (`sc query`), not DB —
+        # runs even if the PG block above failed. 2s timeout per service.
+        try:
+            svc, managed_by = await _a.to_thread(_check_service_registration)
+            with _stats_lock:
+                _stats_cache["service_status"] = svc
+                _stats_cache["service_managed_by"] = managed_by
+        except Exception:
+            # Leave the cached value alone on transient failure.
+            pass
 
         # GPU live telemetry (only if we detected CUDA at startup)
         if _stats_cache["device"].get("kind") == "cuda":

--- a/tests/test_service_status.py
+++ b/tests/test_service_status.py
@@ -1,0 +1,116 @@
+"""Tests for the Windows service registration probe used by /api/stats.
+
+The probe shells out to `sc query <name>` for both WinServerRAG-API and
+WinServerRAG-Daemon. We don't want unit tests to actually touch the
+Service Control Manager (slow, host-dependent), so each test mocks
+subprocess.run with a fake result that mimics one of the four real
+states:
+
+   1) registered + RUNNING       → sc rc=0, "STATE : RUNNING" in stdout
+   2) registered + STOPPED       → sc rc=0, "STATE : STOPPED" in stdout
+   3) not registered             → sc rc=1060
+   4) sc.exe missing (Linux CI)  → FileNotFoundError
+
+Returned label aggregation:
+   both registered → "nssm"
+   exactly one     → "partial"
+   neither         → "manual"
+"""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from src import control_api
+
+
+def _fake_sc_result(rc: int, stdout: str = ""):
+    return subprocess.CompletedProcess(args=[], returncode=rc, stdout=stdout, stderr="")
+
+
+def test_both_running_returns_nssm():
+    running = _fake_sc_result(0, "        STATE              : 4  RUNNING\n")
+    with patch.object(subprocess, "run", return_value=running):
+        out, label = control_api._check_service_registration()
+    assert label == "nssm"
+    assert out["WinServerRAG-API"]["registered"] is True
+    assert out["WinServerRAG-API"]["running"] is True
+    assert out["WinServerRAG-Daemon"]["registered"] is True
+    assert out["WinServerRAG-Daemon"]["running"] is True
+
+
+def test_both_registered_but_stopped_still_nssm():
+    """Service was installed but is not currently running. The
+    registration label still says nssm — running state is a separate
+    field per service and surfaces through the per-service dict."""
+    stopped = _fake_sc_result(0, "        STATE              : 1  STOPPED\n")
+    with patch.object(subprocess, "run", return_value=stopped):
+        out, label = control_api._check_service_registration()
+    assert label == "nssm"
+    assert out["WinServerRAG-API"]["registered"] is True
+    assert out["WinServerRAG-API"]["running"] is False
+
+
+def test_neither_registered_returns_manual():
+    """Default dev mode: venv-launched, no NSSM registration. sc returns
+    rc=1060 'service does not exist'."""
+    not_found = _fake_sc_result(1060, "")
+    with patch.object(subprocess, "run", return_value=not_found):
+        out, label = control_api._check_service_registration()
+    assert label == "manual"
+    assert all(not v["registered"] for v in out.values())
+    assert all(not v["running"] for v in out.values())
+
+
+def test_exactly_one_registered_returns_partial():
+    """Half-uninstall / manual NSSM tweak — flagged so the operator
+    notices the asymmetry. Uses side_effect to return different fakes
+    per call."""
+    running = _fake_sc_result(0, "        STATE              : 4  RUNNING\n")
+    not_found = _fake_sc_result(1060, "")
+    with patch.object(subprocess, "run", side_effect=[running, not_found]):
+        out, label = control_api._check_service_registration()
+    assert label == "partial"
+    # First service queried (alphabetical or list order — currently API):
+    api = out["WinServerRAG-API"]
+    daemon = out["WinServerRAG-Daemon"]
+    assert (api["registered"] is True and daemon["registered"] is False) or \
+           (api["registered"] is False and daemon["registered"] is True)
+
+
+def test_sc_missing_does_not_raise():
+    """On Linux CI runners, sc.exe is absent — FileNotFoundError must be
+    swallowed and treated as 'not registered' so the API stays alive."""
+    with patch.object(subprocess, "run", side_effect=FileNotFoundError("sc")):
+        out, label = control_api._check_service_registration()
+    assert label == "manual"
+    assert all(not v["registered"] for v in out.values())
+
+
+def test_sc_timeout_does_not_raise():
+    """A hung Service Control Manager must not block the stats pump.
+    subprocess.TimeoutExpired is treated as 'not registered'."""
+    with patch.object(subprocess, "run",
+                      side_effect=subprocess.TimeoutExpired(cmd="sc", timeout=2)):
+        out, label = control_api._check_service_registration()
+    assert label == "manual"
+    assert all(not v["registered"] for v in out.values())
+
+
+def test_running_field_only_true_when_state_running():
+    """Don't mistake 'STOPPED' or 'PAUSED' for 'RUNNING' just because
+    the service is registered. The running flag is the precise
+    distinction the mini-monitor uses."""
+    states = {
+        "        STATE              : 4  RUNNING\n":     True,
+        "        STATE              : 1  STOPPED\n":     False,
+        "        STATE              : 7  PAUSED\n":      False,
+        "        STATE              : 3  STOP_PENDING\n": False,
+        "":                                                False,
+    }
+    for stdout, expected_running in states.items():
+        with patch.object(subprocess, "run",
+                          return_value=_fake_sc_result(0, stdout)):
+            out, _ = control_api._check_service_registration()
+        assert out["WinServerRAG-API"]["running"] is expected_running, (
+            f"running flag wrong for STATE line: {stdout!r}")


### PR DESCRIPTION
## Summary

ミニモニタの最上部に **「サービス」「ビルド」 2 行** を追加 — 一目で「NSSM 登録 / 未登録」と「実行中 / 停止中 / アイドル」が判別できるように。

## Display

\`\`\`
┌──────────────────────────────────────────────────────┐
│  ◯ WinServerRAG  [⏸] [Monitor を開く]   ☐         │
├──────────────────────────────────────────────────────┤
│ サービス      ● 登録済 (NSSM)                         │  ← 新
│ ビルド        ⚙ 実行中 (4 workers)                    │  ← 新
│ PG / Drive    PG / Drive                              │
│ ...                                                   │
\`\`\`

## Backend

- `_check_service_registration()` が `sc query` で WinServerRAG-API + WinServerRAG-Daemon を 2s タイムアウト付きで照会
- `_stats_cache` に `service_status` (per-service) + `service_managed_by` (`nssm` / `partial` / `manual`)
- Lifespan で初回 bootstrap、`_stats_pump` で 5s ごと更新
- Linux CI (sc.exe 不在) では FileNotFoundError を吸収、`manual` 扱い

## Frontend

- index.html: 2 行追加 + `.warn` / `.muted` クラス追加
- renderer.js: 状態ロジック (priority: err > paused > active > idle)
- showErr() で API 接続失敗時に "? (API 不通)" 表示

## Test plan

- [x] flake8 緑
- [x] 7 新規テスト pass: 4 状態 (nssm/partial/manual/sc 不在) + timeout 吸収 + RUNNING 厳密判定
- [x] 既存 21 pause/resume tests pass
- [ ] (manual QA) ミニモニタを Ctrl+R で reload、新 2 行が表示
- [ ] (manual QA) NSSM 登録時に「登録済 (NSSM)」、venv 起動時に「未登録 (手動起動)」

🤖 Generated with [Claude Code](https://claude.com/claude-code)