### PR TITLE
feat(mini-monitor): daemon SCM control + ACL relaxation (v1.3)

### DIFF
--- a/desktop/__tests__/service-control.test.js
+++ b/desktop/__tests__/service-control.test.js
@@ -1,0 +1,225 @@
+// Tests for service-control.js — pure-Node, no Electron, no sc.exe needed.
+//
+// Run via:
+//   node --test desktop/__tests__/service-control.test.js
+//
+// We test the parser exhaustively (8 STATE codes + edge cases) and the
+// sc start exit-code classifier. queryService / startService themselves
+// shell out to sc.exe — those are covered by manual QA on a real Windows
+// machine after install. Mocking child_process.execFile isn't worth it
+// when the actual risk lives in real Windows ACL behavior.
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert");
+const path = require("node:path");
+
+const sc = require("../service-control.js");
+
+
+// ---------- parseScQueryOutput ----------
+
+test("parse: STATE 4 RUNNING → running", () => {
+  const out = "SERVICE_NAME: WinServerRAG-Daemon\n" +
+              "        TYPE               : 10  WIN32_OWN_PROCESS\n" +
+              "        STATE              : 4  RUNNING\n";
+  const r = sc.parseScQueryOutput(out, 0);
+  assert.strictEqual(r.kind, "running");
+  assert.strictEqual(r.code, 4);
+});
+
+test("parse: STATE 1 STOPPED → stopped", () => {
+  const out = "        STATE              : 1  STOPPED\n";
+  const r = sc.parseScQueryOutput(out, 0);
+  assert.strictEqual(r.kind, "stopped");
+  assert.strictEqual(r.code, 1);
+});
+
+test("parse: STATE 2 START_PENDING → start_pending", () => {
+  const out = "        STATE              : 2  START_PENDING\n";
+  const r = sc.parseScQueryOutput(out, 0);
+  assert.strictEqual(r.kind, "start_pending");
+  assert.strictEqual(r.code, 2);
+});
+
+test("parse: STATE 3 STOP_PENDING → stop_pending", () => {
+  const out = "        STATE              : 3  STOP_PENDING\n";
+  const r = sc.parseScQueryOutput(out, 0);
+  assert.strictEqual(r.kind, "stop_pending");
+  assert.strictEqual(r.code, 3);
+});
+
+test("parse: STATE 5 CONTINUE_PENDING → continue_pending", () => {
+  const out = "        STATE              : 5  CONTINUE_PENDING\n";
+  const r = sc.parseScQueryOutput(out, 0);
+  assert.strictEqual(r.kind, "continue_pending");
+  assert.strictEqual(r.code, 5);
+});
+
+test("parse: STATE 6 PAUSE_PENDING → pause_pending", () => {
+  const out = "        STATE              : 6  PAUSE_PENDING\n";
+  const r = sc.parseScQueryOutput(out, 0);
+  assert.strictEqual(r.kind, "pause_pending");
+  assert.strictEqual(r.code, 6);
+});
+
+test("parse: STATE 7 PAUSED → paused", () => {
+  const out = "        STATE              : 7  PAUSED\n";
+  const r = sc.parseScQueryOutput(out, 0);
+  assert.strictEqual(r.kind, "paused");
+  assert.strictEqual(r.code, 7);
+});
+
+test("parse: rc=1060 (service does not exist) → not_installed", () => {
+  // sc.exe writes its own "FAILED 1060" text to stdout/stderr but the
+  // crucial signal is the process exit code 1060.
+  const r = sc.parseScQueryOutput("[SC] OpenService FAILED 1060", 1060);
+  assert.strictEqual(r.kind, "not_installed");
+  assert.strictEqual(r.code, 1060);
+});
+
+test("parse: rc=0 but no STATE line → unknown", () => {
+  // Truncated / weird output. Don't pretend we know.
+  const r = sc.parseScQueryOutput("garbage", 0);
+  assert.strictEqual(r.kind, "unknown");
+});
+
+test("parse: rc=0 with STATE 999 (impossible) → unknown", () => {
+  const r = sc.parseScQueryOutput("STATE : 999", 0);
+  assert.strictEqual(r.kind, "unknown");
+});
+
+test("parse: rc=other (not 0 / 1060) → unknown", () => {
+  // E.g. ACL refused etc. Not our responsibility to parse, but we shouldn't crash.
+  const r = sc.parseScQueryOutput("", 1234);
+  assert.strictEqual(r.kind, "unknown");
+  assert.strictEqual(r.code, 1234);
+});
+
+test("parse: localized JP STATE label still parses (numeric is locale-stable)", () => {
+  // Hypothetical JA Windows variant. The text after the number can vary;
+  // the digit cannot.
+  const out = "        STATE              : 4  実行中\n";
+  const r = sc.parseScQueryOutput(out, 0);
+  assert.strictEqual(r.kind, "running");
+  assert.strictEqual(r.code, 4);
+});
+
+
+// ---------- classifyStartExit ----------
+
+test("startExit: 0 → started", () => {
+  const r = sc.classifyStartExit(0);
+  assert.strictEqual(r.kind, "started");
+});
+
+test("startExit: 5 → access_denied (SDDL hint)", () => {
+  const r = sc.classifyStartExit(5);
+  assert.strictEqual(r.kind, "access_denied");
+  assert.match(r.message, /SDDL/);
+});
+
+test("startExit: 1056 → already_running (idempotent OK)", () => {
+  const r = sc.classifyStartExit(1056);
+  assert.strictEqual(r.kind, "already_running");
+});
+
+test("startExit: 1060 → not_installed", () => {
+  const r = sc.classifyStartExit(1060);
+  assert.strictEqual(r.kind, "not_installed");
+});
+
+test("startExit: 1068 → dependency_failed (API note in message)", () => {
+  const r = sc.classifyStartExit(1068);
+  assert.strictEqual(r.kind, "dependency_failed");
+  assert.match(r.message, /API|依存/);
+});
+
+test("startExit: 1053 → no_response", () => {
+  const r = sc.classifyStartExit(1053);
+  assert.strictEqual(r.kind, "no_response");
+});
+
+test("startExit: 9999 (unknown) → unknown_error with code preserved", () => {
+  const r = sc.classifyStartExit(9999);
+  assert.strictEqual(r.kind, "unknown_error");
+  assert.strictEqual(r.code, 9999);
+});
+
+
+// ---------- scExePath ----------
+
+test("scExePath: defaults to %SystemRoot%\\System32\\sc.exe", () => {
+  const original = process.env.SystemRoot;
+  process.env.SystemRoot = "C:\\Windows";
+  try {
+    assert.strictEqual(
+      sc.scExePath(),
+      path.join("C:\\Windows", "System32", "sc.exe"),
+    );
+  } finally {
+    process.env.SystemRoot = original;
+  }
+});
+
+test("scExePath: honors non-default SystemRoot", () => {
+  const original = process.env.SystemRoot;
+  process.env.SystemRoot = "D:\\Win11";
+  try {
+    assert.strictEqual(
+      sc.scExePath(),
+      path.join("D:\\Win11", "System32", "sc.exe"),
+    );
+  } finally {
+    process.env.SystemRoot = original;
+  }
+});
+
+test("scExePath: falls back to C:\\Windows when SystemRoot unset", () => {
+  const original = process.env.SystemRoot;
+  delete process.env.SystemRoot;
+  try {
+    assert.strictEqual(
+      sc.scExePath(),
+      path.join("C:\\Windows", "System32", "sc.exe"),
+    );
+  } finally {
+    if (original !== undefined) process.env.SystemRoot = original;
+  }
+});
+
+
+// ---------- detectDevMode ----------
+
+test("detectDevMode: returns isDev=false when no .venv nearby", () => {
+  // /tmp on most systems definitely does not have a .venv tree.
+  const tmpDir = require("node:os").tmpdir();
+  const r = sc.detectDevMode(tmpDir);
+  assert.strictEqual(r.isDev, false);
+});
+
+test("detectDevMode: walks up to 3 levels — sibling .venv detected", () => {
+  // We can't easily fake a .venv on disk in a unit test. Instead, we
+  // verify the contract: the function does not throw, returns the
+  // expected shape, and isDev is a boolean.
+  const r = sc.detectDevMode("/nonexistent/path/that/has/no/venv");
+  assert.strictEqual(typeof r.isDev, "boolean");
+  assert.strictEqual(r.isDev, false);
+});
+
+
+// ---------- exports surface ----------
+
+test("module exports the expected public API", () => {
+  assert.ok(typeof sc.parseScQueryOutput === "function");
+  assert.ok(typeof sc.queryService === "function");
+  assert.ok(typeof sc.classifyStartExit === "function");
+  assert.ok(typeof sc.startService === "function");
+  assert.ok(typeof sc.scExePath === "function");
+  assert.ok(typeof sc.detectDevMode === "function");
+  assert.ok(sc.STATE_NAMES && sc.STATE_NAMES[4] === "running");
+  assert.ok(sc.PENDING_STATES instanceof Set);
+  assert.ok(sc.PENDING_STATES.has(2));
+  assert.ok(sc.PENDING_STATES.has(3));
+  assert.ok(!sc.PENDING_STATES.has(4));
+});

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -183,7 +183,11 @@
            service (production deploy) or a manually-launched venv process
            (dev mode); "ビルド" tells them whether RAG indexing is live,
            paused on purpose, or just idle (no work to do). -->
-      <div class="row"><span class="k">サービス</span><span class="v" id="service-status">-</span></div>
+      <!-- v1.3: this row is now Daemon-only (was service registration via API
+           in PR #28). Renderer pulls from Electron `sc query` directly so the
+           value is honest even when the API is down. id stays the same to
+           keep the renderer code change minimal. -->
+      <div class="row"><span class="k">Daemon</span><span class="v" id="service-status">-</span></div>
       <div class="row"><span class="k">ビルド</span><span class="v" id="build-status">-</span></div>
       <div class="row"><span class="k">PG / Drive</span><span class="v" id="conns">- / -</span></div>
       <div class="row"><span class="k">FDs enabled</span><span class="v" id="fds">-/-</span></div>

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -4,8 +4,17 @@
 
 const { app, BrowserWindow, shell, ipcMain, Menu } = require("electron");
 const path = require("path");
+const sc = require("./service-control.js");
 
 const API_URL = process.env.WINSERVERRAG_API_URL || "http://127.0.0.1:17600";
+
+// Service names — hardcoded on purpose. The installer registers exactly
+// these (see installer/install-services.ps1). v1.3 doesn't need a
+// manifest file because `sc query <name>` and `sc start <name>` only
+// take a name, not a path. Codex review flagged path-resolution as
+// overbuilt; we deferred it.
+const DAEMON_SERVICE = "WinServerRAG-Daemon";
+const API_SERVICE    = "WinServerRAG-API";
 
 let win;
 
@@ -74,4 +83,35 @@ ipcMain.handle("get-always-on-top", () => {
 });
 ipcMain.on("set-always-on-top", (_evt, on) => {
   if (win) win.setAlwaysOnTop(!!on);
+});
+
+// IPC: daemon status — the renderer polls this every 5s. Returns the
+// numeric-parsed SCM state for WinServerRAG-Daemon. Independent of the
+// FastAPI lifecycle (the whole point of v1.3).
+//
+// Shape: { kind: "running" | "stopped" | ... | "not_installed" | "unknown",
+//          code: <numeric>, devMode: { isDev: bool, ...} }
+ipcMain.handle("daemon-status", async () => {
+  const status = await sc.queryService(DAEMON_SERVICE);
+  // Augment with dev-mode detection so the renderer can decide between
+  // "✕ 未インストール" (production deploy missing the installer) vs
+  // "💻 dev mode (venv で起動してください)" (developer running from repo).
+  const dev = sc.detectDevMode(__dirname);
+  return { ...status, devMode: dev };
+});
+
+// IPC: start the daemon. Triggered by the renderer's ▶ button when the
+// service is in STOPPED state. Works without UAC because the installer
+// (installer/install-services.ps1) granted SERVICE_START to the
+// WinServerRAG Operators local group at install time.
+//
+// Returns the classified exit:
+//   { kind: "started" | "already_running" | "access_denied" | "not_installed"
+//          | "dependency_failed" | "no_response" | "unknown_error",
+//     message: <user-facing string>, code: <numeric> }
+//
+// The renderer should poll daemon-status afterwards to observe the
+// START_PENDING → RUNNING transition (no need to block here).
+ipcMain.handle("daemon-start", async () => {
+  return sc.startService(DAEMON_SERVICE);
 });

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -6,4 +6,9 @@ contextBridge.exposeInMainWorld("winsrv", {
   getApiUrl: () => ipcRenderer.invoke("get-api-url"),
   getAlwaysOnTop: () => ipcRenderer.invoke("get-always-on-top"),
   setAlwaysOnTop: (on) => ipcRenderer.send("set-always-on-top", !!on),
+  // v1.3 daemon control — independent of the FastAPI lifecycle.
+  // daemonStatus() polls SCM directly so the daemon row updates even
+  // when the API is down (precisely when the operator wants honesty).
+  daemonStatus: () => ipcRenderer.invoke("daemon-status"),
+  daemonStart:  () => ipcRenderer.invoke("daemon-start"),
 });

--- a/desktop/renderer.js
+++ b/desktop/renderer.js
@@ -91,37 +91,132 @@ function setIndicator(kind) {
 let _pausedState = null;
 let _pauseInflight = false;
 
+// --- Daemon state cache (v1.3) ----------------------------------------
+// Populated by a separate 5s polling loop that calls window.winsrv.daemonStatus()
+// (Electron main → sc query). Kept independent from /api/stats so that
+// "API down + Daemon up" is still visible. Shape mirrors service-control.js:
+//   { kind, code, devMode: { isDev, venvPython?, repoRoot? } }
+let _daemonState = null;
+// Tri-state: null = first poll hasn't completed, "..." = inflight start,
+// "ok" = idle, "err" = last start failed (sticky until next poll succeeds).
+let _daemonStartFlight = null;
+
 function setPauseUI(paused) {
   const btn = $("pause-btn");
   if (!btn) return;
-  if (paused) {
-    btn.textContent = "▶";
-    btn.title = "サービスを再開する";
-    btn.classList.add("paused");
-  } else {
-    btn.textContent = "⏸";
-    btn.title = "サービスを一時停止する (新規タスク取得を止める。進行中タスクは完走)";
-    btn.classList.remove("paused");
+  // The button label depends on a 2D state: (daemon SCM state, API paused).
+  // Most states are handled here based on the daemon kind we last saw.
+  // The API-derived `paused` flag is only meaningful when the daemon
+  // is actually running.
+  const d = _daemonState && _daemonState.kind;
+  if (d === "running" || d === "paused") {
+    if (paused) {
+      btn.textContent = "▶";
+      btn.title = "サービスを再開する";
+      btn.classList.add("paused");
+    } else {
+      btn.textContent = "⏸";
+      btn.title = "サービスを一時停止する (新規タスク取得を止める。進行中タスクは完走)";
+      btn.classList.remove("paused");
+    }
+    btn.disabled = _pauseInflight;
+    return;
   }
-  btn.disabled = _pauseInflight;
+  if (d === "stopped") {
+    btn.textContent = "▶";
+    btn.title = "Daemon サービスを起動する (UAC 不要)";
+    btn.classList.add("paused");
+    btn.disabled = !!_daemonStartFlight;
+    return;
+  }
+  if (d === "start_pending" || d === "stop_pending" ||
+      d === "continue_pending" || d === "pause_pending") {
+    btn.textContent = "⏳";
+    btn.title = "サービス遷移中...";
+    btn.disabled = true;
+    return;
+  }
+  if (d === "not_installed") {
+    const isDev = _daemonState.devMode && _daemonState.devMode.isDev;
+    btn.textContent = isDev ? "💻" : "⊘";
+    btn.title = isDev ? "dev mode 検出 — クリックで起動方法を表示"
+                      : "Daemon が未インストール — クリックでインストーラー案内";
+    btn.disabled = false;
+    return;
+  }
+  // unknown / null
+  btn.textContent = "?";
+  btn.title = "Daemon 状態取得中...";
+  btn.disabled = true;
 }
 
 async function togglePause() {
+  // Dispatch on daemon state — the button's meaning depends on it.
+  // Codex review made this explicit: a single "pause" handler can't
+  // safely paper over "service is stopped" vs "service is running".
+  const d = _daemonState && _daemonState.kind;
+
+  // 1) Daemon not registered. Show a help dialog instead of doing
+  //    anything system-mutating. Mini-monitor never installs.
+  if (d === "not_installed") {
+    const isDev = _daemonState.devMode && _daemonState.devMode.isDev;
+    if (isDev) showDevModeDialog(_daemonState.devMode);
+    else       showNotInstalledDialog();
+    return;
+  }
+
+  // 2) Daemon registered but stopped → start it (no UAC, SDDL relaxed).
+  if (d === "stopped") {
+    if (_daemonStartFlight) return;
+    _daemonStartFlight = "starting";
+    setPauseUI(_pausedState);
+    try {
+      const r = await window.winsrv.daemonStart();
+      if (r.kind === "started" || r.kind === "already_running") {
+        // Optimistic: surface PENDING immediately. Next pollDaemon()
+        // will pick up the real RUNNING transition (≤5s lag).
+        _daemonState = { kind: "start_pending", code: 2, devMode: _daemonState.devMode };
+        renderDaemonRow(_daemonState);
+      } else {
+        // Hard fail (access_denied / not_installed / dependency_failed
+        // / no_response / unknown_error). Show in debug overlay; the
+        // daemon row will reflect reality on the next poll.
+        DBG.lastFailReason = `daemon-start: ${r.kind} — ${r.message}`;
+        DBG.lastFailAt = new Date();
+        if (isDebugOpen()) renderDebug();
+      }
+    } catch (e) {
+      DBG.lastFailReason = `daemon-start IPC: ${e && e.message || e}`;
+      DBG.lastFailAt = new Date();
+      if (isDebugOpen()) renderDebug();
+    } finally {
+      _daemonStartFlight = null;
+      setPauseUI(_pausedState);
+    }
+    return;
+  }
+
+  // 3) PENDING — button is disabled, but defensive no-op anyway.
+  if (d === "start_pending" || d === "stop_pending" ||
+      d === "continue_pending" || d === "pause_pending") {
+    return;
+  }
+
+  // 4) Default path: daemon is RUNNING (or PAUSED, treated as running).
+  //    Standard pause/resume API call. _pausedState may still be null
+  //    on the first ever tick — bail in that case.
   if (_pauseInflight || _pausedState == null) return;
   const target = !_pausedState;
-  const path = target ? "/api/daemon/pause" : "/api/daemon/resume";
+  const apiPath = target ? "/api/daemon/pause" : "/api/daemon/resume";
   _pauseInflight = true;
-  setPauseUI(_pausedState);  // re-render with disabled=true
+  setPauseUI(_pausedState);
   try {
-    const r = await fetch(API + path, { method: "POST" });
+    const r = await fetch(API + apiPath, { method: "POST" });
     if (!r.ok) throw new Error("HTTP " + r.status);
     const state = await r.json();
     _pausedState = !!state.paused;
     setPauseUI(_pausedState);
   } catch (e) {
-    // Revert: keep the previous state on error. The next /api/stats poll
-    // will reconcile if the DB was actually updated. Surface the error
-    // in the debug overlay (Ctrl+Shift+D) so the operator can see why.
     DBG.lastFailReason = `pause-toggle: ${e && e.message || e}`;
     DBG.lastFailAt = new Date();
     if (isDebugOpen()) renderDebug();
@@ -129,6 +224,93 @@ async function togglePause() {
     _pauseInflight = false;
     setPauseUI(_pausedState);
   }
+}
+
+// --- Daemon SCM polling ------------------------------------------------
+// Independent loop, 5s cadence. Runs whether or not /api/stats responds
+// — that's the v1.3 promise to the operator.
+async function pollDaemon() {
+  try {
+    const status = await window.winsrv.daemonStatus();
+    _daemonState = status;
+    renderDaemonRow(status);
+    setPauseUI(_pausedState);
+  } catch (e) {
+    // Electron IPC genuinely shouldn't fail unless the main process is
+    // gone. Surface in debug overlay; leave _daemonState alone.
+    DBG.lastFailReason = `daemon-status IPC: ${e && e.message || e}`;
+    DBG.lastFailAt = new Date();
+    if (isDebugOpen()) renderDebug();
+  }
+}
+
+// Render the daemon row from a service-control.js result. Independent of
+// /api/stats — see comment in tick().
+function renderDaemonRow(state) {
+  const el = $("service-status");
+  if (!el) return;
+  switch (state.kind) {
+    case "running":
+    case "paused":  // treat SCM-level PAUSED same as RUNNING for UI
+      el.textContent = "● 実行中";
+      el.className = "v ok";
+      break;
+    case "stopped":
+      el.textContent = "■ 停止中 (登録済)";
+      el.className = "v muted";
+      break;
+    case "start_pending":
+      el.textContent = "⏳ 起動中...";
+      el.className = "v warn";
+      break;
+    case "stop_pending":
+      el.textContent = "⏳ 停止中...";
+      el.className = "v warn";
+      break;
+    case "continue_pending":
+    case "pause_pending":
+      el.textContent = "⏳ 遷移中...";
+      el.className = "v warn";
+      break;
+    case "not_installed":
+      if (state.devMode && state.devMode.isDev) {
+        el.textContent = "💻 dev mode (venv)";
+        el.className = "v muted";
+      } else {
+        el.textContent = "✕ 未インストール";
+        el.className = "v err";
+      }
+      break;
+    case "unknown":
+    default:
+      el.textContent = "? 状態取得失敗";
+      el.className = "v warn";
+  }
+}
+
+function showNotInstalledDialog() {
+  alert(
+    "Daemon サービスが未インストールです。\n\n" +
+    "本機能を使うには、管理者権限で\n" +
+    "  WinServerRAG-Setup-x.y.z.exe\n" +
+    "を実行してインストーラーを完了してください。\n\n" +
+    "https://github.com/GridWorldOrganization/GridWorldRAG/releases"
+  );
+}
+
+function showDevModeDialog(dev) {
+  const cmd = (dev.repoRoot || "<repo>") +
+              "\\.venv\\Scripts\\python.exe -m src.rag_daemon";
+  // Use prompt so the user can copy the command (alert doesn't allow copy
+  // in Electron without extra plumbing). Pre-fill the command as the
+  // default value; the operator presses Ctrl+C inside the prompt and
+  // dismisses with Esc.
+  prompt(
+    "dev mode 検出: NSSM サービスは未登録です。\n" +
+    "venv で Daemon を起動してください (別ターミナルで実行):\n\n" +
+    "↓ コマンド (Ctrl+C でコピー、Esc で閉じる)",
+    cmd
+  );
 }
 
 function flashTick() {
@@ -269,32 +451,15 @@ async function tick() {
     }
 
     // --- rows
-    // Service registration row — most important operator-facing status.
-    // Tells the operator at a glance whether the running daemon is the
-    // production NSSM-registered Windows service or an ad-hoc venv-
-    // launched dev process. /api/stats.service_managed_by ∈
-    // {"nssm","partial","manual"} based on `sc query` results for
-    // WinServerRAG-API and WinServerRAG-Daemon.
-    const svcEl = $("service-status");
-    const managed = s.service_managed_by;
-    if (managed === "nssm") {
-      svcEl.textContent = "● 登録済 (NSSM)";
-      svcEl.className = "v ok";
-    } else if (managed === "partial") {
-      // Exactly one service registered — usually means a half-uninstall
-      // or a manual NSSM tweak. Worth flagging so the operator notices.
-      svcEl.textContent = "▲ 一部登録 (要確認)";
-      svcEl.className = "v warn";
-    } else {
-      // "manual" or undefined — venv-launched dev mode is normal here.
-      svcEl.textContent = "○ 未登録 (手動起動)";
-      svcEl.className = "v muted";
-    }
+    // Daemon row — DAEMON-ONLY status, independent of /api/stats.
+    // Renders from _daemonState (Electron `sc query` poll, 5s). When the
+    // poll hasn't completed yet, _daemonState is null and we leave the
+    // row alone (will be filled on the next pollDaemon tick). Once we
+    // have a value, this row is authoritative and never gets cleared by
+    // showErr() — that's the v1.3 promise: "API down ≠ daemon unknown".
+    if (_daemonState !== null) renderDaemonRow(_daemonState);
 
-    // Build status row — explicit text label for indexing state. Mirrors
-    // the indicator color logic but spells it out so a glance at the row
-    // alone tells you "実行中" / "停止中" / "アイドル" without having to
-    // decode an indicator dot. Priority matches setIndicator() above:
+    // Build row — explicit text label for indexing state. /api/stats only.
     //   error/dead daemon → 障害
     //   paused=true       → 停止中（手動停止）
     //   activeWorkers > 0 → 実行中 (N workers)
@@ -456,11 +621,10 @@ function showErr() {
   $("files").textContent = "-";
   $("chunks").textContent = "-";
   $("dbsize").textContent = "-";
-  // Service / build status: API down means we can't tell either, so
-  // surface that honestly rather than freezing the last known good value.
-  const svcEl = $("service-status");
-  svcEl.textContent = "? (API 不通)";
-  svcEl.className = "v err";
+  // v1.3: Daemon row is independent of /api/stats — populated by the
+  // SCM poll (winsrv.daemonStatus). DO NOT clear it here. The whole
+  // point of v1.3 is "API down ≠ daemon unknown". Build row is API-only,
+  // so we mark it explicitly.
   const buildEl = $("build-status");
   buildEl.textContent = "? (API 不通)";
   buildEl.className = "v err";
@@ -517,4 +681,10 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   tick();
   setInterval(tick, 250);
+
+  // v1.3: separate Daemon SCM polling loop, 5s cadence. Independent of
+  // /api/stats. First poll immediate so the daemon row populates as
+  // soon as possible; subsequent polls every 5s.
+  pollDaemon();
+  setInterval(pollDaemon, 5000);
 });

--- a/desktop/service-control.js
+++ b/desktop/service-control.js
@@ -1,0 +1,225 @@
+// service-control.js — pure-Node helpers for querying / starting Windows
+// services from the Electron main process. Kept dependency-free and
+// side-effect-light so it can be unit-tested under node:test without
+// spinning up an Electron context.
+//
+// Why this module exists
+// ----------------------
+// Mini-monitor's primary job is monitoring the daemon, NOT the API. If we
+// only checked daemon state via the FastAPI /api/stats endpoint (PR #28),
+// the mini-monitor would say "状態取得失敗" any time the API was down —
+// which is precisely when the operator needs the mini-monitor most.
+// Talking to the Windows Service Control Manager directly via `sc query`
+// gives us a second, independent data stream.
+//
+// Security note: we never invoke `sc create` / `nssm install` from here.
+// All install operations happen in the Inno Setup installer
+// (installer/install-services.ps1). That installer is the only piece
+// that needs admin. After install, this module's `startService()` works
+// without UAC because the installer's PowerShell relaxes the service
+// SDDL to grant SERVICE_START + SERVICE_QUERY_STATUS to the local group
+// `WinServerRAG Operators`.
+//
+// Codex-flagged constraints honored here:
+//   - sc.exe is invoked at its full path %SystemRoot%\System32\sc.exe
+//     (avoids PATH-injection / sc.exe-on-path replacement).
+//   - State is parsed from the numeric `STATE :  4  RUNNING` line
+//     (4 = RUNNING). Localized text on JP Windows might not say "RUNNING".
+//   - sc start error codes are mapped concretely (5/1056/1060/1068/1053).
+//   - Pending states (2/3/5/6) are surfaced as a distinct kind, not
+//     conflated with UNKNOWN.
+"use strict";
+
+const { execFile } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+// ---------------------------------------------------------------------
+// State machine (numeric, locale-independent)
+// ---------------------------------------------------------------------
+// Sourced from Microsoft SERVICE_STATUS dwCurrentState values:
+//   1 SERVICE_STOPPED          ■ stopped
+//   2 SERVICE_START_PENDING    ⏳ starting
+//   3 SERVICE_STOP_PENDING     ⏳ stopping
+//   4 SERVICE_RUNNING          ● running
+//   5 SERVICE_CONTINUE_PENDING ⏳ resuming
+//   6 SERVICE_PAUSE_PENDING    ⏳ pausing (rare for our daemon)
+//   7 SERVICE_PAUSED           (rare; mini-monitor treats as RUNNING for UI purposes)
+const STATE_NAMES = {
+  1: "stopped",
+  2: "start_pending",
+  3: "stop_pending",
+  4: "running",
+  5: "continue_pending",
+  6: "pause_pending",
+  7: "paused",
+};
+
+const PENDING_STATES = new Set([2, 3, 5, 6]);
+
+
+// ---------------------------------------------------------------------
+// sc.exe absolute path
+// ---------------------------------------------------------------------
+function scExePath() {
+  // %SystemRoot%\System32\sc.exe — avoids PATH lookup. Honors a different
+  // SystemRoot if the OS is genuinely installed elsewhere (uncommon).
+  const root = process.env.SystemRoot || "C:\\Windows";
+  return path.join(root, "System32", "sc.exe");
+}
+
+
+// ---------------------------------------------------------------------
+// sc query parsing
+// ---------------------------------------------------------------------
+// `sc query <name>` writes a multi-line block; we extract the first
+// "STATE              : N  TEXT" line and return N. The numeric is
+// locale-stable, the text is not.
+//
+// Returns one of:
+//   { kind: "running" | "stopped" | "start_pending" | "stop_pending" |
+//           "continue_pending" | "pause_pending" | "paused", code: N }
+//   { kind: "not_installed", code: 1060 }
+//   { kind: "unknown", code: <something>, raw: <stdout> }
+function parseScQueryOutput(stdout, returncode) {
+  if (returncode === 1060) {
+    return { kind: "not_installed", code: 1060 };
+  }
+  if (returncode !== 0) {
+    return { kind: "unknown", code: returncode, raw: String(stdout || "") };
+  }
+  const text = String(stdout || "");
+  // STATE              : 4  RUNNING
+  // Whitespace + ":" + whitespace + digit. Tolerates locale-varying text after.
+  const m = text.match(/STATE\s*:\s*(\d+)/);
+  if (!m) {
+    return { kind: "unknown", code: returncode, raw: text };
+  }
+  const n = parseInt(m[1], 10);
+  const name = STATE_NAMES[n];
+  if (!name) {
+    return { kind: "unknown", code: returncode, raw: text };
+  }
+  return { kind: name, code: n };
+}
+
+
+// ---------------------------------------------------------------------
+// queryService — high-level: returns parsed state for a single service.
+// Surfaces FileNotFoundError / TimeoutError as `unknown` so the mini-
+// monitor never crashes from a missing sc.exe (Linux CI) or a hung SCM.
+// ---------------------------------------------------------------------
+function queryService(serviceName, opts = {}) {
+  const exe = opts.scExe || scExePath();
+  const timeoutMs = opts.timeoutMs || 3000;
+  return new Promise((resolve) => {
+    execFile(exe, ["query", serviceName], {
+      timeout: timeoutMs,
+      windowsHide: true,
+    }, (err, stdout, stderr) => {
+      // sc returns rc=1060 "service does not exist" via the err.code path.
+      const rc = err && typeof err.code === "number" ? err.code : (err ? -1 : 0);
+      // execFile timeouts surface err.killed = true; err.code may be undefined.
+      if (err && err.killed) {
+        resolve({ kind: "unknown", code: -1, raw: "(timeout)" });
+        return;
+      }
+      // ENOENT (sc.exe missing) → unknown, not crash.
+      if (err && err.code === "ENOENT") {
+        resolve({ kind: "unknown", code: -1, raw: "(sc.exe not found)" });
+        return;
+      }
+      resolve(parseScQueryOutput(stdout, rc));
+    });
+  });
+}
+
+
+// ---------------------------------------------------------------------
+// sc start — exit code map
+// ---------------------------------------------------------------------
+// Codex-flagged: don't treat all non-zero as a generic failure. The
+// operator's recovery action depends on which.
+const START_ERROR_CLASSES = {
+  0:    { kind: "started",        message: "started" },
+  5:    { kind: "access_denied",  message: "アクセス拒否 (SDDL 確認)" },
+  1056: { kind: "already_running", message: "既に実行中" },           // idempotent
+  1060: { kind: "not_installed",   message: "未インストール" },
+  1068: { kind: "dependency_failed", message: "依存サービス (API) 起動失敗" },
+  1053: { kind: "no_response",     message: "応答タイムアウト" },
+};
+
+function classifyStartExit(code) {
+  if (code in START_ERROR_CLASSES) return START_ERROR_CLASSES[code];
+  return { kind: "unknown_error", message: `不明なエラー (exit ${code})`, code };
+}
+
+
+// ---------------------------------------------------------------------
+// startService — kick off `sc start`, do NOT poll here. Caller polls
+// queryService() to observe the START_PENDING → RUNNING transition.
+// ---------------------------------------------------------------------
+function startService(serviceName, opts = {}) {
+  const exe = opts.scExe || scExePath();
+  const timeoutMs = opts.timeoutMs || 5000;
+  return new Promise((resolve) => {
+    execFile(exe, ["start", serviceName], {
+      timeout: timeoutMs,
+      windowsHide: true,
+    }, (err, stdout) => {
+      const rc = err && typeof err.code === "number" ? err.code : (err ? -1 : 0);
+      if (err && err.killed) {
+        resolve({ kind: "no_response", message: "起動コマンドがタイムアウト", code: -1 });
+        return;
+      }
+      if (err && err.code === "ENOENT") {
+        resolve({ kind: "unknown_error", message: "sc.exe not found", code: -1 });
+        return;
+      }
+      resolve(classifyStartExit(rc));
+    });
+  });
+}
+
+
+// ---------------------------------------------------------------------
+// Dev-mode detection
+// ---------------------------------------------------------------------
+// Used to differentiate two "service not installed" cases:
+//   1) Operator hasn't run the installer (production deploy, but missing)
+//   2) Operator is a developer working from the repo (no installer ever)
+//
+// Heuristic: the mini-monitor app dir is a sibling of `.venv\Scripts\python.exe`
+// in the repo. We walk up at most 2 directories from `__dirname` looking for
+// `.venv\Scripts\python.exe`. If found AND service is `not_installed`, it's
+// dev mode and the warning dialog tells the operator to run
+// `python -m src.rag_daemon` from a venv-activated terminal.
+function detectDevMode(startDir) {
+  let dir = startDir || __dirname;
+  for (let depth = 0; depth < 3; depth++) {
+    const venvPython = path.join(dir, ".venv", "Scripts", "python.exe");
+    try {
+      if (fs.existsSync(venvPython)) {
+        return { isDev: true, venvPython, repoRoot: dir };
+      }
+    } catch {
+      // ignore
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return { isDev: false };
+}
+
+
+module.exports = {
+  STATE_NAMES,
+  PENDING_STATES,
+  scExePath,
+  parseScQueryOutput,
+  queryService,
+  classifyStartExit,
+  startService,
+  detectDevMode,
+};

--- a/installer/inno/WinServerRAG.iss
+++ b/installer/inno/WinServerRAG.iss
@@ -85,6 +85,10 @@ Source: "..\..\MCP.md";      DestDir: "{app}\docs"; Flags: ignoreversion
 Source: "..\..\CHANGELOG.md"; DestDir: "{app}\docs"; Flags: ignoreversion
 Source: "..\..\LICENSE";     DestDir: "{app}\docs"; Flags: ignoreversion
 
+; v1.3 service-installer PowerShell script — does the NSSM register +
+; SDDL relaxation + Operators group bookkeeping. Lives next to nssm.exe.
+Source: "..\install-services.ps1"; DestDir: "{app}\bin"; Flags: ignoreversion
+
 [Dirs]
 ; Per-machine writable dirs. Permissions: standard users can write logs
 ; and run backups, but cannot edit config (admin-only).
@@ -101,88 +105,21 @@ Name: "{group}\{cm:UninstallProgram,{#AppName}}"; Filename: "{uninstallexe}"
 Name: "{userdesktop}\{#AppName} Mini";   Filename: "{app}\mini\{#AppExeMini}"; Tasks: desktopicon
 
 [Run]
-; --- Service registration (NSSM). Runs after [Files] copy completes.
+; --- v1.3 service registration: delegated to install-services.ps1 ---
 ;
-; The API service starts first; the daemon depends on it because the
-; daemon assumes /api/stats is reachable for heartbeat reporting.
-
-; -- API service --
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "install {#ServiceApi} ""{app}\bin\winserverrag-api\winserverrag-api.exe"""; \
-  Flags: runhidden; StatusMsg: "Registering {#ServiceApi}..."
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceApi} AppDirectory ""{app}\bin\winserverrag-api"""; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceApi} AppStdout ""{commonappdata}\{#AppName}\logs\api.out.log"""; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceApi} AppStderr ""{commonappdata}\{#AppName}\logs\api.err.log"""; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceApi} AppRotateFiles 1"; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceApi} AppRotateBytes 10485760"; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceApi} AppEnvironmentExtra WINSERVERRAG_CONFIG_DIR=""{commonappdata}\{#AppName}\config"""; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceApi} Start SERVICE_AUTO_START"; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceApi} Description ""WinServerRAG control API + web monitor (FastAPI on :17600)"""; \
-  Flags: runhidden
-
-; -- Daemon service --
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "install {#ServiceDaemon} ""{app}\bin\winserverrag-daemon\winserverrag-daemon.exe"""; \
-  Flags: runhidden; StatusMsg: "Registering {#ServiceDaemon}..."
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceDaemon} AppDirectory ""{app}\bin\winserverrag-daemon"""; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceDaemon} AppStdout ""{commonappdata}\{#AppName}\logs\daemon.out.log"""; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceDaemon} AppStderr ""{commonappdata}\{#AppName}\logs\daemon.err.log"""; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceDaemon} AppRotateFiles 1"; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceDaemon} AppRotateBytes 10485760"; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceDaemon} AppEnvironmentExtra WINSERVERRAG_CONFIG_DIR=""{commonappdata}\{#AppName}\config"""; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceDaemon} Start SERVICE_AUTO_START"; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceDaemon} DependOnService {#ServiceApi}"; \
-  Flags: runhidden
-
-Filename: "{app}\bin\nssm.exe"; \
-  Parameters: "set {#ServiceDaemon} Description ""WinServerRAG indexer daemon (rag_daemon multi-threaded)"""; \
-  Flags: runhidden
+; Replaces the long sequence of `nssm install/set` calls that lived
+; here in v1.2. The PowerShell script is idempotent (re-run on an
+; existing install updates params in place), creates the local
+; `WinServerRAG Operators` group, adds the installing user, and
+; relaxes the service SDDL so the mini-monitor can `sc start` without
+; UAC. Single source of truth for service registration — re-runnable
+; from a future "repair" path.
+;
+; -ExecutionPolicy Bypass: signed scripts not in scope; script ships
+; alongside nssm.exe under {app}\bin which is admin-only writable.
+Filename: "{cmd}"; \
+  Parameters: "/C powershell.exe -NoProfile -ExecutionPolicy Bypass -File ""{app}\bin\install-services.ps1"" -InstallRoot ""{app}"" -DataRoot ""{commonappdata}\{#AppName}"" -OperatorUser ""{username}"""; \
+  Flags: runhidden; StatusMsg: "Registering services + relaxing service ACL..."
 
 ; -- DB init (manual / not registered as a service) --
 ;
@@ -196,13 +133,12 @@ Filename: "{app}\mini\{#AppExeMini}"; \
   Flags: nowait postinstall skipifsilent
 
 [UninstallRun]
-; Stop + remove services BEFORE [UninstallDelete] removes the exe files.
-; Order matters: stop, wait, remove. NSSM `remove ... confirm` skips the
-; interactive Y/N prompt.
-Filename: "{app}\bin\nssm.exe"; Parameters: "stop {#ServiceDaemon}";   Flags: runhidden; RunOnceId: "stop_daemon"
-Filename: "{app}\bin\nssm.exe"; Parameters: "stop {#ServiceApi}";      Flags: runhidden; RunOnceId: "stop_api"
-Filename: "{app}\bin\nssm.exe"; Parameters: "remove {#ServiceDaemon} confirm"; Flags: runhidden; RunOnceId: "rm_daemon"
-Filename: "{app}\bin\nssm.exe"; Parameters: "remove {#ServiceApi} confirm";    Flags: runhidden; RunOnceId: "rm_api"
+; v1.3: delegate to install-services.ps1 -Uninstall, which stops both
+; services, removes them, and deletes the local Operators group.
+; Single source of truth, mirrors the [Run] block above.
+Filename: "{cmd}"; \
+  Parameters: "/C powershell.exe -NoProfile -ExecutionPolicy Bypass -File ""{app}\bin\install-services.ps1"" -InstallRoot ""{app}"" -DataRoot ""{commonappdata}\{#AppName}"" -Uninstall"; \
+  Flags: runhidden; RunOnceId: "uninstall_services"
 
 [UninstallDelete]
 ; Logs / backups / config in ProgramData are intentionally PRESERVED on

--- a/installer/install-services.ps1
+++ b/installer/install-services.ps1
@@ -1,0 +1,242 @@
+#requires -Version 5
+<#
+.SYNOPSIS
+    Register / unregister WinServerRAG-API and WinServerRAG-Daemon as
+    NSSM-backed Windows services, with relaxed service ACLs so the
+    mini-monitor can start them without UAC.
+
+.DESCRIPTION
+    Called in two contexts:
+      1. Inno Setup installer [Run] block — `-InstallRoot ... -DataRoot ...`
+      2. Mini-monitor "repair" path (future) — same args, idempotent
+
+    Idempotent: every step either creates a new resource or updates the
+    existing one in place. Re-running on a working install is a no-op.
+
+    Why a separate PS1 (Codex review):
+      - Inno Setup [Run] does not loop, so 25+ NSSM commands are a
+        copy-paste mess that's hard to keep idempotent. Bash-style
+        scripting is much cleaner here.
+      - Future mini-monitor "repair" button can re-invoke this same
+        script via UAC, single source of truth.
+
+    Why the SDDL relaxation:
+      - Default service DACL grants SERVICE_START to admins only.
+      - We grant SERVICE_START + SERVICE_QUERY_STATUS to a local group
+        `WinServerRAG Operators` (NOT Authenticated Users — Microsoft
+        explicitly calls out granting service rights to AU as a common
+        security mistake; it can include domain principals on a domain-
+        joined machine).
+      - SERVICE_STOP is NOT granted to the operator group. The
+        mini-monitor's button never service-stops the daemon (it
+        pauses via the API instead). Granting STOP would expand the
+        attack surface for no functional benefit.
+
+.PARAMETER InstallRoot
+    The folder where the v1.2 installer placed bin\ (e.g.,
+    "C:\Program Files\WinServerRAG"). The script expects:
+      $InstallRoot\bin\nssm.exe
+      $InstallRoot\bin\winserverrag-api\winserverrag-api.exe
+      $InstallRoot\bin\winserverrag-daemon\winserverrag-daemon.exe
+
+.PARAMETER DataRoot
+    Where logs / backups / config live (e.g., "C:\ProgramData\WinServerRAG").
+    Logs go to $DataRoot\logs\{api,daemon}.{out,err}.log.
+
+.PARAMETER OperatorUser
+    A user to add to the local "WinServerRAG Operators" group on
+    install. Pass the original (non-elevated) user from Inno Setup's
+    {username} constant. Defaults to $env:USERNAME if not provided
+    (works when the script is run interactively as a normal admin).
+
+.PARAMETER Uninstall
+    If set, stop+remove both services and delete the local Operators
+    group. Used by the installer's [UninstallRun] block.
+#>
+
+param(
+    [Parameter(Mandatory=$true)] [string] $InstallRoot,
+    [Parameter(Mandatory=$true)] [string] $DataRoot,
+    [string] $OperatorUser = "",
+    [switch] $Uninstall
+)
+
+$ErrorActionPreference = "Stop"
+
+$ServiceApi    = "WinServerRAG-API"
+$ServiceDaemon = "WinServerRAG-Daemon"
+$OperatorGroup = "WinServerRAG Operators"
+
+$NssmExe   = Join-Path $InstallRoot "bin\nssm.exe"
+$ApiExe    = Join-Path $InstallRoot "bin\winserverrag-api\winserverrag-api.exe"
+$DaemonExe = Join-Path $InstallRoot "bin\winserverrag-daemon\winserverrag-daemon.exe"
+$ConfigDir = Join-Path $DataRoot "config"
+$LogDir    = Join-Path $DataRoot "logs"
+
+
+# ---------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------
+function Log($msg) { Write-Host "[install-services] $msg" }
+
+function Service-Exists($name) {
+    $r = & sc.exe query $name 2>&1
+    return $LASTEXITCODE -eq 0
+}
+
+function Group-Exists($name) {
+    $r = & net.exe localgroup $name 2>&1
+    return $LASTEXITCODE -eq 0
+}
+
+function Stop-IfRunning($name) {
+    if (Service-Exists $name) {
+        Log "Stopping $name (if running)..."
+        & sc.exe stop $name 2>&1 | Out-Null
+        # Best-effort: don't error if already stopped.
+    }
+}
+
+
+# ---------------------------------------------------------------------
+# Uninstall path
+# ---------------------------------------------------------------------
+if ($Uninstall) {
+    Log "Uninstall mode."
+    Stop-IfRunning $ServiceDaemon
+    Stop-IfRunning $ServiceApi
+    if (Service-Exists $ServiceDaemon) {
+        Log "Removing $ServiceDaemon..."
+        & $NssmExe remove $ServiceDaemon confirm 2>&1 | Out-Null
+    }
+    if (Service-Exists $ServiceApi) {
+        Log "Removing $ServiceApi..."
+        & $NssmExe remove $ServiceApi confirm 2>&1 | Out-Null
+    }
+    if (Group-Exists $OperatorGroup) {
+        Log "Removing local group $OperatorGroup..."
+        & net.exe localgroup $OperatorGroup /delete 2>&1 | Out-Null
+    }
+    Log "Uninstall complete."
+    exit 0
+}
+
+
+# ---------------------------------------------------------------------
+# Install / repair path
+# ---------------------------------------------------------------------
+Log "Install mode. InstallRoot=$InstallRoot DataRoot=$DataRoot"
+
+# 1. Pre-flight — verify the binaries the installer dropped are reachable.
+foreach ($p in @($NssmExe, $ApiExe, $DaemonExe)) {
+    if (-not (Test-Path $p)) {
+        throw "Required binary not found: $p (did the installer's [Files] section run first?)"
+    }
+}
+
+# 2. Make sure the writable dirs exist.
+foreach ($d in @($ConfigDir, $LogDir)) {
+    if (-not (Test-Path $d)) {
+        Log "Creating $d"
+        New-Item -ItemType Directory -Force -Path $d | Out-Null
+    }
+}
+
+# 3. Local Operators group — create-if-missing, idempotent.
+if (-not (Group-Exists $OperatorGroup)) {
+    Log "Creating local group: $OperatorGroup"
+    & net.exe localgroup $OperatorGroup /add /comment:"Members can start/query the WinServerRAG services without UAC." 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to create local group $OperatorGroup (exit $LASTEXITCODE)"
+    }
+} else {
+    Log "Local group already exists: $OperatorGroup"
+}
+
+# 4. Add the operator user (Inno Setup's {username}, or $env:USERNAME).
+if (-not $OperatorUser) { $OperatorUser = $env:USERNAME }
+if ($OperatorUser) {
+    Log "Adding user '$OperatorUser' to '$OperatorGroup' (if not already)..."
+    # `net localgroup ... /add` returns 2 if the user is already a member;
+    # not an error in our context. Suppress.
+    & net.exe localgroup $OperatorGroup $OperatorUser /add 2>&1 | Out-Null
+}
+
+# 5. Install API service — idempotent. If it exists, fall through to
+#    `nssm set` calls below to re-apply the params (Codex: blind
+#    `nssm install` on existing service mismatches the repair semantics).
+function Install-NssmService($name, $exe) {
+    if (Service-Exists $name) {
+        Log "Service exists, will update params: $name"
+    } else {
+        Log "Installing service: $name -> $exe"
+        & $NssmExe install $name $exe 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "nssm install $name failed: $LASTEXITCODE" }
+    }
+}
+
+Install-NssmService $ServiceApi    $ApiExe
+Install-NssmService $ServiceDaemon $DaemonExe
+
+# 6. Apply / re-apply NSSM params for both services.
+function Set-NssmParams($name, $appDir, $logBase, $env, $depends) {
+    & $NssmExe set $name AppDirectory       $appDir         | Out-Null
+    & $NssmExe set $name AppStdout          "$LogDir\$logBase.out.log" | Out-Null
+    & $NssmExe set $name AppStderr          "$LogDir\$logBase.err.log" | Out-Null
+    & $NssmExe set $name AppRotateFiles     1               | Out-Null
+    & $NssmExe set $name AppRotateBytes     10485760        | Out-Null
+    & $NssmExe set $name AppEnvironmentExtra "WINSERVERRAG_CONFIG_DIR=$ConfigDir" | Out-Null
+    & $NssmExe set $name Start              SERVICE_AUTO_START | Out-Null
+    if ($depends) {
+        & $NssmExe set $name DependOnService $depends | Out-Null
+    }
+}
+
+Set-NssmParams $ServiceApi    (Split-Path $ApiExe)    "api"    $ConfigDir $null
+Set-NssmParams $ServiceDaemon (Split-Path $DaemonExe) "daemon" $ConfigDir $ServiceApi
+
+# 7. Set descriptions (cosmetic, services.msc).
+& $NssmExe set $ServiceApi    Description "WinServerRAG control API + web monitor (FastAPI on :17600)" | Out-Null
+& $NssmExe set $ServiceDaemon Description "WinServerRAG indexer daemon (rag_daemon multi-threaded)"   | Out-Null
+
+# 8. SDDL relaxation — the v1.3 piece. Grant SERVICE_QUERY_STATUS +
+#    SERVICE_START to the Operators group, NOT to Authenticated Users.
+#
+# The default DACL we want to keep:
+#   D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)         SYSTEM full
+#   (A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)   Builtin\Administrators full
+#   (A;;CCLCSWLOCRRC;;;IU)                 Interactive Users default
+#   (A;;CCLCSWLOCRRC;;;SU)                 Service principals default
+#   S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)  audit
+# Plus our ACE:
+#   (A;;LCRP;;;<SID-of-WinServerRAG-Operators>)
+#     LC = LIST_OBJECT
+#     RP = SERVICE_START
+# We deliberately omit WP (SERVICE_STOP).
+function Get-LocalGroupSid($name) {
+    $obj = New-Object System.Security.Principal.NTAccount($env:COMPUTERNAME, $name)
+    return $obj.Translate([System.Security.Principal.SecurityIdentifier]).Value
+}
+$OperatorSid = Get-LocalGroupSid $OperatorGroup
+
+$Sddl = "D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)" `
+      + "(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)" `
+      + "(A;;CCLCSWLOCRRC;;;IU)" `
+      + "(A;;CCLCSWLOCRRC;;;SU)" `
+      + "(A;;LCRP;;;$OperatorSid)" `
+      + "S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)"
+
+foreach ($svc in @($ServiceApi, $ServiceDaemon)) {
+    Log "Applying SDDL to $svc (Operators get LIST + START only)..."
+    $r = & sc.exe sdset $svc $Sddl 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        # Don't crash — the service still works for admins. Just warn.
+        # Common cause: SDDL syntax mismatch on an oddly-configured host.
+        Write-Warning "sc sdset $svc failed: $r (exit $LASTEXITCODE) — Operators group will not have non-admin start rights"
+    }
+}
+
+Log "Install complete. Services registered with auto-start."
+Log "Operator group '$OperatorGroup' has SERVICE_START + SERVICE_QUERY_STATUS only (no SERVICE_STOP)."
+Log "Members: $((& net.exe localgroup $OperatorGroup) -join ', ')"
+exit 0


### PR DESCRIPTION
## Summary

設計書 (PR #29) を実装。ミニモニタを **API 不在でも daemon 状態を表示**、未起動 daemon を **UAC 不要で起動**できるツールに格上げ。

- ミニモニタ → Electron main → `sc query/start` 直叩き (5s 間隔ポーリング)
- API 不通でも daemon 行は独立して更新
- ボタン: 8 状態 (running/paused/stopped/4 pending/not_installed dev|prod)
- 未インストール時は警告ダイアログのみ、mini-monitor は **install しない**
- インストーラーが `WinServerRAG Operators` グループ作成 + SDDL 緩和で UAC 不要

## Codex 指摘 12 件全採用済 (PR #29 で lock-in、本 PR で実装)

- 数値 STATE parse / sc.exe フルパス / pending state 独立表示
- sc start error code 細別 (5/1056/1060/1068/1053)
- NSSM 冪等化 (detect+update、blind install しない)
- SDDL は Operators group + START+QUERY のみ (STOP は付与しない、AU 拒否)
- 2-stream UI 合成 (showErr が daemon 行を触らない)
- API service install ペア (Daemon → API DependOnService)

## Test plan

- [x] flake8 緑
- [x] Python tests 28 件全 pass (既存)
- [x] Node native tests 25 件全 pass (新規 `service-control.test.js`)
- [x] CI でも緑になる見込み (Python / lint / Node test)
- [ ] (post-merge) Manual QA on installed Windows machine:
  - Production: installer → mini-monitor → ▶ → RUNNING within 30s, no UAC prompt
  - Dev mode: 警告ダイアログ + コピーボタン
  - API down + daemon up: Daemon 行は緑、Build 行 "? (API 不通)"
  - PAUSE_PENDING / START_PENDING の遷移表示

## Plan reference

`~/.gstack/projects/GridWorldRAG/tobisako-master-eng-plan-mini-monitor-daemon-v13-20260426.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)