### PR TITLE
fix(mini,installer): prevent Electron orphan processes on install/crash

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -2,9 +2,40 @@
 // A tiny frameless-ish always-on-top window that shows health metrics
 // and has one button to open the full web UI in the default browser.
 
-const { app, BrowserWindow, shell, ipcMain, Menu } = require("electron");
+const { app, BrowserWindow, shell, ipcMain, Menu, dialog } = require("electron");
 const path = require("path");
-const sc = require("./service-control.js");
+
+// v1.3.2: catch unhandled exceptions in the main process. Without this,
+// a failure during init (e.g. require() of a missing module) shows the
+// default Electron error dialog and leaves the GPU helper / utility
+// child processes orphaned in the background after the user closes it.
+// Forcing app.exit() from the handler kills the whole process tree.
+process.on("uncaughtException", (err) => {
+  console.error("[main] uncaughtException:", err);
+  try {
+    if (app.isReady()) {
+      dialog.showErrorBox(
+        "WinServerRAG Mini — Fatal error",
+        String((err && err.stack) || err)
+      );
+    }
+  } catch {}
+  app.exit(1);
+});
+
+// v1.3.2: guard the service-control.js require. PR #34 fixed the asar
+// packaging miss that caused this to throw, but a top-level require()
+// is a footgun: any future bundle regression lands the user back in
+// the orphan-process state. Catch the error, defer the user-facing
+// dialog until app is ready, and exit cleanly so no helpers leak.
+let sc = null;
+let scLoadErr = null;
+try {
+  sc = require("./service-control.js");
+} catch (err) {
+  scLoadErr = err;
+  console.error("[main] failed to load service-control.js:", err);
+}
 
 const API_URL = process.env.WINSERVERRAG_API_URL || "http://127.0.0.1:17600";
 
@@ -60,7 +91,19 @@ function createWindow() {
   win.loadFile("index.html");
 }
 
-app.whenReady().then(createWindow);
+app.whenReady().then(() => {
+  if (scLoadErr) {
+    dialog.showErrorBox(
+      "WinServerRAG Mini — Bundle error",
+      "service-control.js is missing from the app bundle.\n\n" +
+        "This is an installer packaging bug. Please reinstall WinServerRAG.\n\n" +
+        String(scLoadErr)
+    );
+    app.exit(2);
+    return;
+  }
+  createWindow();
+});
 
 app.on("window-all-closed", () => {
   app.quit();

--- a/installer/inno/WinServerRAG.iss
+++ b/installer/inno/WinServerRAG.iss
@@ -139,10 +139,22 @@ Filename: "powershell.exe"; \
 ; auto-run it during install because PostgreSQL might not be ready yet
 ; on a fresh box (newly installed, not yet started).
 
-; -- Optional: launch mini-monitor at the end --
-Filename: "{app}\mini\{#AppExeMini}"; \
-  Description: "{cm:LaunchProgram,{#AppName} Mini Monitor}"; \
-  Flags: nowait postinstall skipifsilent
+; -- v1.3.2: Mini Monitor is NOT auto-launched at install end. --
+;
+; v1.3.0/1 fired Mini via `Flags: nowait postinstall skipifsilent`.
+; Two problems with that:
+;   1. The installer fires-and-forgets, so a Mini crash during init
+;      (e.g. asar missing service-control.js — the PR #34 bug) orphans
+;      Electron's GPU/utility helper subprocesses with no cleanup.
+;      Repeated install attempts accumulated 3+ orphan processes.
+;   2. Showing Mini before the user has confirmed install success is
+;      awkward — the Inno Setup "Finish" page should be the success
+;      signal, not a popup window racing it.
+;
+; Mini Monitor is now Start-Menu / desktop-shortcut launch only.
+; Defense-in-depth: desktop/main.js also has uncaughtException +
+; require-guard handlers (v1.3.2) so any future Mini crash exits cleanly
+; instead of leaking helper processes.
 
 [UninstallRun]
 ; v1.3: delegate to install-services.ps1 -Uninstall, which stops both


### PR DESCRIPTION
## Summary

ユーザーがインストーラーのJavaScriptエラーダイアログを閉じた後、`WinServerRAG Mini` プロセスが3個残留した問題への根本対応。

3つの設計欠陥が重なって発生:

1. **`desktop/main.js:7` のトップレベル `require("./service-control.js")`** — asar に同梱されない（PR #34 で修正済）と main プロセスが起動時に throw。Electron は既に GPU helper / utility 子プロセスを spawn 済で、これらが orphan 化。

2. **`process.on('uncaughtException')` ハンドラ不在** — Electron デフォルトはダイアログを出すだけ。ユーザーが閉じても子プロセスツリーは残留。

3. **Inno Setup `[Run]` の `nowait postinstall skipifsilent`** — Mini を fire-and-forget で起動。インストーラーは Mini の生死を追跡せず、クラッシュ時の orphan 掃除責任が誰にもない。

## Fixes

- `desktop/main.js`: `process.on('uncaughtException')` で `app.exit(1)` → プロセスツリー全強制終了
- `desktop/main.js`: `service-control.js` の `require` を try/catch で包み、`app.whenReady()` 後に `dialog.showErrorBox` → `app.exit(2)` でクリーン終了
- `installer/inno/WinServerRAG.iss`: postinstall Mini 起動エントリを削除。スタートメニュー/デスクトップショートカット起動のみに変更

PR #34 は今回の bundle bug を直すが、A+B は **将来 main プロセスがクラッシュした時にも orphan を出さない防御層**、C は **インストーラーが Mini に責任を持たない設計** に正す。

## Test plan

- [ ] CI lint passes
- [ ] CI installer build produces `WinServerRAG-Setup-1.3.0.exe`
- [ ] Local install: services register, no JS error dialog, no orphan process after Finish page
- [ ] Force re-install (overwrite existing): no accumulating orphans
- [ ] Manual main.js crash test (e.g. inject `throw new Error()` at top): error dialog shows, user clicks OK, NO Mini processes remain in Task Manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)