### PR TITLE
feat(installer): graceful upgrade over existing install

### DIFF
--- a/installer/inno/WinServerRAG.iss
+++ b/installer/inno/WinServerRAG.iss
@@ -62,6 +62,13 @@ ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 ; UninstallDisplayIcon={app}\mini\{#AppExeMini}   ; needs an .ico — Mini Monitor exe is not a .ico
 ChangesEnvironment=no
+; v1.3.2: graceful upgrade — close any running Mini Monitor before
+; [Files] tries to overwrite mini\WinServerRAG Mini.exe. `force` =
+; kill if the user ignores the prompt. Daemon/API services are
+; stopped separately in PrepareToInstall (Code section) since they
+; aren't owned by a foreground window.
+CloseApplications=force
+RestartApplications=no
 
 [Languages]
 Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
@@ -201,5 +208,79 @@ begin
       'Continue installation anyway?',
       mbConfirmation, MB_YESNO);
     Result := (Resp = IDYES);
+  end;
+end;
+
+// v1.3.2: graceful upgrade support.
+//
+// If a previous WinServerRAG is installed and its services are running,
+// the daemon/API exes are locked by NSSM-spawned processes. [Files]
+// would fail to overwrite them. We stop the services in PrepareToInstall
+// (the documented Inno hook for "do this before [Files]"), wait for
+// SCM to confirm STOPPED, and let install proceed. install-services.ps1
+// then sees existing services and `nssm remove`s them for a clean
+// re-register (drops any stale AppParameters / AppEnvironmentExtra).
+
+function ServiceExists(const SvcName: String): Boolean;
+var
+  ResultCode: Integer;
+begin
+  Exec(ExpandConstant('{cmd}'),
+       '/C sc query "' + SvcName + '" >NUL 2>&1',
+       '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  Result := (ResultCode = 0);
+end;
+
+function ServiceIsStopped(const SvcName: String): Boolean;
+var
+  ResultCode: Integer;
+begin
+  // findstr exit 0 means "STOPPED" line was found in `sc query` output.
+  Exec(ExpandConstant('{cmd}'),
+       '/C sc query "' + SvcName + '" | findstr /C:"STATE" | findstr /C:"STOPPED" >NUL 2>&1',
+       '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  Result := (ResultCode = 0);
+end;
+
+function StopServiceAndWait(const SvcName: String): Boolean;
+var
+  ResultCode, WaitCount: Integer;
+begin
+  Result := True;
+  if not ServiceExists(SvcName) then Exit; // Fresh install — nothing to do.
+
+  // sc stop is best-effort; if already stopped it returns 1062 which is fine.
+  Exec(ExpandConstant('{cmd}'),
+       '/C sc stop "' + SvcName + '" >NUL 2>&1',
+       '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+
+  // Poll for STOPPED state, up to 30s. NSSM's stop-method default is
+  // graceful-then-kill at 5s, so 30s is plenty even for a stuck daemon.
+  WaitCount := 0;
+  while WaitCount < 30 do
+  begin
+    if ServiceIsStopped(SvcName) then Exit;
+    Sleep(1000);
+    WaitCount := WaitCount + 1;
+  end;
+  Result := False; // Timeout.
+end;
+
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+begin
+  Result := '';
+  // Stop daemon FIRST — it depends on API, so the API stop won't take
+  // effect cleanly while the daemon is still hitting it.
+  if not StopServiceAndWait('{#ServiceDaemon}') then
+  begin
+    Result := '{#ServiceDaemon} did not reach STOPPED state within 30 seconds. ' +
+              'Stop it manually via services.msc and re-run the installer.';
+    Exit;
+  end;
+  if not StopServiceAndWait('{#ServiceApi}') then
+  begin
+    Result := '{#ServiceApi} did not reach STOPPED state within 30 seconds. ' +
+              'Stop it manually via services.msc and re-run the installer.';
+    Exit;
   end;
 end;

--- a/installer/install-services.ps1
+++ b/installer/install-services.ps1
@@ -170,6 +170,37 @@ foreach ($p in @($NssmExe, $ApiExe, $DaemonExe)) {
     }
 }
 
+# 1.5 v1.3.2: upgrade-clean re-register.
+#
+# If we're running on top of an older WinServerRAG, the services already
+# exist with the prior version's NSSM config in the registry. Inno
+# Setup's PrepareToInstall (in the .iss [Code] section) has already
+# stopped them so [Files] could overwrite the bundled exes — but the
+# SCM entries themselves still point at the OLD AppDirectory and may
+# carry stale AppParameters / AppEnvironmentExtra from the previous
+# version. `nssm set` updates fields in-place but cannot remove a
+# field that the new install no longer needs.
+#
+# Cleanest fix: remove the services here, fall through to the
+# `Install-NssmService` calls below which re-create them fresh.
+# Falls back to update-in-place if `nssm remove` doesn't take.
+foreach ($svc in @($ServiceDaemon, $ServiceApi)) {
+    if (Service-Exists $svc) {
+        Log "Existing service detected, removing for clean re-register: $svc"
+        # PrepareToInstall already stopped these, but be defensive — a
+        # user invoking this script manually as a "repair" step might
+        # not have stopped them first.
+        Stop-IfRunning $svc
+        Start-Sleep -Seconds 2
+        & $NssmExe remove $svc confirm 2>&1 | Out-Null
+        if (Service-Exists $svc) {
+            Log "Warning: $svc still exists after nssm remove; install path will update params in place instead."
+        } else {
+            Log "Removed $svc."
+        }
+    }
+}
+
 # 2. Make sure the writable dirs exist.
 foreach ($d in @($ConfigDir, $LogDir)) {
     if (-not (Test-Path $d)) {


### PR DESCRIPTION
## Summary

既存 WinServerRAG（旧バージョン）の上から再インストールしても、サービス停止・ファイルロック解除・古い NSSM レジストリ設定の掃除を自動で行うようにする。

ユーザー要望: 「もし古いバージョンがインストール済なら、円滑に上書き更新するようにして。既存デーモンが動いていたら、停止させて削除し、そしてインストールするように。」

## Problem

現在のインストーラーはフレッシュインストール前提:

1. **ファイルロック**: NSSM が起動した daemon/API 実行ファイルを掴んでいる → `[Files]` が上書きできない
2. **Mini Monitor のロック**: ユーザーが実行中だと `mini\WinServerRAG Mini.exe` も上書き不可
3. **古い NSSM 設定の残留**: レジストリに古い `AppParameters` / `AppEnvironmentExtra` が残り、`nssm set` では削除できない

## Fix (3層)

### A. `installer/inno/WinServerRAG.iss` [Setup]
```ini
CloseApplications=force
RestartApplications=no
```
Inno Setup が `[Files]` で上書き対象になる exe を所有する実行中アプリを kill。Mini Monitor 用。

### B. `installer/inno/WinServerRAG.iss` [Code]: `PrepareToInstall` 追加
```pascal
function PrepareToInstall(var NeedsRestart: Boolean): String;
begin
  Result := '';
  if not StopServiceAndWait('{#ServiceDaemon}') then ... ;
  if not StopServiceAndWait('{#ServiceApi}') then ... ;
end;
```
- daemon → API の順で停止（依存関係の逆順）
- `sc.exe stop` 発行後、`sc query | findstr STOPPED` で 1 秒間隔・最大 30 秒ポーリング
- タイムアウトしたら wizard に「services.msc で手動停止して再実行」エラー表示

### C. `installer/install-services.ps1`: 既存サービスを `nssm remove`
インストール経路の冒頭、pre-flight 後・dirs 作成前に:
```powershell
foreach ($svc in @($ServiceDaemon, $ServiceApi)) {
    if (Service-Exists $svc) {
        Stop-IfRunning $svc
        & $NssmExe remove $svc confirm
    }
}
```
クリーンに削除してから下流の `Install-NssmService` で新規登録 → 古いレジストリ値は完全に消える。
削除に失敗したら下流の update-in-place 経路にフォールバック（defense in depth）。

## Effect

- フレッシュインストール: A は no-op、B は `ServiceExists` false で即 return、C は分岐外
- 旧バージョン上書き: A が Mini を kill、B が daemon→API 停止、C が NSSM remove → 完全クリーン再登録

## Test plan

- [ ] CI lint passes
- [ ] CI installer build produces `WinServerRAG-Setup-1.3.0.exe`
- [ ] **Fresh install path** (no prior install): services register, no spurious dialogs
- [ ] **Upgrade path**: install v1.3.0, start daemon, run installer again → services stop → files overwrite without "in use" dialog → services re-register fresh
- [ ] **Mini Monitor running during install**: Inno's CloseApplications kills it without hang
- [ ] **Daemon stuck/non-responsive**: PrepareToInstall reaches 30s timeout → user sees actionable error

🤖 Generated with [Claude Code](https://claude.com/claude-code)