### PR TITLE
hardening(installer,mini,daemon): surface install errors + graceful stop

### DIFF
--- a/config/config.v2.env.example
+++ b/config/config.v2.env.example
@@ -5,7 +5,10 @@
 GOOGLE_EMAIL=you@example.com
 GOOGLE_OAUTH_CLIENT_ID=xxxx.apps.googleusercontent.com
 GOOGLE_OAUTH_CLIENT_SECRET=xxxx
-GOOGLE_TOKEN_PATH=config/token.pickle
+# Path to the OAuth refresh token. Plain filename = next to this file
+# (i.e. CONFIG_DIR/token.pickle). Legacy "config/token.pickle" form is
+# still honored for backward compat (resolves under DATA_ROOT).
+GOOGLE_TOKEN_PATH=token.pickle
 
 # --- PostgreSQL ---
 PGHOST=localhost

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -70,6 +70,27 @@ function createWindow() {
       nodeIntegration: false,
     },
   });
+  // v1.3.2: catch renderer-process crashes. Without this, a fatal JS
+  // error in renderer.js leaves a blank always-on-top window with the
+  // main process still alive — user has no way to recover except Task
+  // Manager. uncaughtException (set above) only covers the main
+  // process; renderer crashes are a separate event.
+  win.webContents.on("render-process-gone", (_e, details) => {
+    console.error("[main] renderer gone:", details);
+    try {
+      dialog.showErrorBox(
+        "WinServerRAG Mini — Renderer crashed",
+        `Reason: ${details.reason}\nExit code: ${details.exitCode}\n\n` +
+        "The mini-monitor will exit. Re-launch from the Start Menu."
+      );
+    } catch {}
+    app.exit(3);
+  });
+  // Render process becoming unresponsive (infinite loop, blocked main
+  // thread) — surface but don't auto-kill; user may want to wait.
+  win.on("unresponsive", () => {
+    console.warn("[main] renderer unresponsive");
+  });
   win.setMenuBarVisibility(false);
   // Hidden accelerators: menu is not visible but accelerators still fire.
   // Lets the user pop DevTools / reload / force-refresh when diagnosing the UI.

--- a/installer/inno/WinServerRAG.iss
+++ b/installer/inno/WinServerRAG.iss
@@ -225,9 +225,16 @@ function ServiceExists(const SvcName: String): Boolean;
 var
   ResultCode: Integer;
 begin
-  Exec(ExpandConstant('{cmd}'),
-       '/C sc query "' + SvcName + '" >NUL 2>&1',
-       '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  // v1.3.2: Exec returns False if cmd.exe couldn't even be spawned
+  // (security software block, low-resource OS, etc). ResultCode is
+  // undefined in that case — must not be trusted.
+  if not Exec(ExpandConstant('{cmd}'),
+              '/C sc query "' + SvcName + '" >NUL 2>&1',
+              '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    Result := False; // Can't probe → behave as "doesn't exist", let install proceed.
+    Exit;
+  end;
   Result := (ResultCode = 0);
 end;
 
@@ -236,9 +243,13 @@ var
   ResultCode: Integer;
 begin
   // findstr exit 0 means "STOPPED" line was found in `sc query` output.
-  Exec(ExpandConstant('{cmd}'),
-       '/C sc query "' + SvcName + '" | findstr /C:"STATE" | findstr /C:"STOPPED" >NUL 2>&1',
-       '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  if not Exec(ExpandConstant('{cmd}'),
+              '/C sc query "' + SvcName + '" | findstr /C:"STATE" | findstr /C:"STOPPED" >NUL 2>&1',
+              '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+  begin
+    Result := False;
+    Exit;
+  end;
   Result := (ResultCode = 0);
 end;
 
@@ -250,12 +261,15 @@ begin
   if not ServiceExists(SvcName) then Exit; // Fresh install — nothing to do.
 
   // sc stop is best-effort; if already stopped it returns 1062 which is fine.
+  // Exec spawn-failure is non-fatal — fall through to the polling loop, which
+  // will time out and surface a useful error if the service is genuinely stuck.
   Exec(ExpandConstant('{cmd}'),
        '/C sc stop "' + SvcName + '" >NUL 2>&1',
        '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
 
-  // Poll for STOPPED state, up to 30s. NSSM's stop-method default is
-  // graceful-then-kill at 5s, so 30s is plenty even for a stuck daemon.
+  // Poll for STOPPED state, up to 30s. NSSM's stop-method (configured in
+  // install-services.ps1 to 30s console) is the actual graceful-shutdown
+  // budget; 30s here is the wrapper that confirms it took.
   WaitCount := 0;
   while WaitCount < 30 do
   begin
@@ -283,4 +297,79 @@ begin
               'Stop it manually via services.msc and re-run the installer.';
     Exit;
   end;
+end;
+
+// v1.3.2: surface install-services.ps1 failures to the user.
+//
+// The PS1 has a try/catch sentinel (writes install-services-FAILED.txt
+// on any uncaught error, since PR #34). But Inno Setup's [Run] block
+// does NOT inspect exit codes — runhidden + no Check: callback means a
+// PS1 throw silently completes the install. Users see "Setup
+// successful" while services are unregistered. This was the silent
+// failure path that motivated PR #37.
+//
+// CurStepChanged(ssPostInstall) fires AFTER all [Run] entries complete
+// and BEFORE the Finish wizard page. We check for the FAILED.txt
+// sentinel; if present + recent (<10 min old), show a clear error
+// dialog with the log path. The install still completes (files are
+// already on disk), but the user knows they need to investigate, and
+// /api/stats's "service registered" probe will reflect reality.
+
+function FileAgeMinutes(const Path: String): Integer;
+var
+  Modified: TDateTime;
+  NowTs: TDateTime;
+begin
+  Result := -1;
+  if not FileExists(Path) then Exit;
+  try
+    Modified := FileDateToDateTime(FileAge(Path));
+    // Inno Setup's Pascal Script exposes `Now` from SysUtils-equivalents.
+    // TDateTime is a Double where integer part = days. (Now - Modified)
+    // is a fractional day count; *24*60 → minutes.
+    NowTs := Now;
+    Result := Round((NowTs - Modified) * 24 * 60);
+  except
+    Result := -1;
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  FailPath, LogDir, AppRoot, DataRoot, ManualCmd: String;
+  AgeMin: Integer;
+begin
+  if CurStep <> ssPostInstall then Exit;
+
+  AppRoot  := ExpandConstant('{app}');
+  DataRoot := ExpandConstant('{commonappdata}\{#AppName}');
+  LogDir   := DataRoot + '\logs';
+  FailPath := LogDir + '\install-services-FAILED.txt';
+
+  if not FileExists(FailPath) then Exit;
+
+  // Stale sentinel from a prior install? Ignore anything older than 10
+  // minutes — current install would have been quicker than that.
+  AgeMin := FileAgeMinutes(FailPath);
+  if (AgeMin < 0) or (AgeMin > 10) then Exit;
+
+  ManualCmd :=
+    'powershell -ExecutionPolicy Bypass -File "' +
+    AppRoot + '\bin\install-services.ps1" ' +
+    '-InstallRoot "' + AppRoot + '" -DataRoot "' + DataRoot + '"';
+
+  MsgBox(
+    '⚠ サービス登録に失敗しました' + #13#10 + #13#10 +
+    'インストーラーはファイルのコピーは完了しましたが、' + #13#10 +
+    'WinServerRAG-API / WinServerRAG-Daemon の登録 (NSSM) が' + #13#10 +
+    'エラーで止まっています。' + #13#10 + #13#10 +
+    '詳細ログ:' + #13#10 +
+    '  ' + FailPath + #13#10 +
+    '  ' + LogDir + '\install-services-install-*.log' + #13#10 + #13#10 +
+    '対応策:' + #13#10 +
+    '  1) 上のログを確認してエラー原因を特定' + #13#10 +
+    '  2) 修正後、インストーラーを再実行 (graceful upgrade で復旧)' + #13#10 +
+    '  3) または管理者 PowerShell で手動再実行:' + #13#10 +
+    '     ' + ManualCmd,
+    mbError, MB_OK);
 end;

--- a/installer/inno/WinServerRAG.iss
+++ b/installer/inno/WinServerRAG.iss
@@ -103,9 +103,17 @@ Source: "..\..\LICENSE";     DestDir: "{app}\docs"; Flags: ignoreversion
 Source: "..\install-services.ps1"; DestDir: "{app}\bin"; Flags: ignoreversion
 
 [Dirs]
-; Per-machine writable dirs. Permissions: standard users can write logs
-; and run backups, but cannot edit config (admin-only).
-Name: "{commonappdata}\{#AppName}\config";  Permissions: users-readexec admins-modify
+; Per-machine writable dirs.
+;
+; v1.3.2: config dir is admin-only. install-services.ps1 follows up
+; with `icacls /inheritance:r /grant:r Administrators:(OI)(CI)F
+; SYSTEM:(OI)(CI)F` to BREAK inheritance from %ProgramData% (which
+; otherwise grants Authenticated Users read access). Inno's
+; [Dirs] Permissions only adds explicit ACEs, it does not strip
+; inherited ones — that's why the icacls call is required for the
+; secrets in config.v2.env (GOOGLE_OAUTH_CLIENT_SECRET, PGPASSWORD,
+; API_BEARER_TOKEN) to actually be admin-only readable.
+Name: "{commonappdata}\{#AppName}\config";  Permissions: admins-full
 Name: "{commonappdata}\{#AppName}\logs";    Permissions: users-modify
 Name: "{commonappdata}\{#AppName}\backups"; Permissions: users-modify
 Name: "{commonappdata}\{#AppName}\backups\daily";  Permissions: users-modify

--- a/installer/install-services.ps1
+++ b/installer/install-services.ps1
@@ -220,6 +220,35 @@ foreach ($d in @($ConfigDir, $LogDir)) {
     }
 }
 
+# 2.5 v1.3.2: lock down the config directory ACL.
+#
+# config.v2.env contains GOOGLE_OAUTH_CLIENT_SECRET, PGPASSWORD, and
+# (optionally) API_BEARER_TOKEN. Inno Setup's [Dirs] only ADDS explicit
+# ACEs — it does not break inherited ACEs from %ProgramData% which by
+# default grants Authenticated Users read access to subdirectories.
+# Without this step, any local user can `type config.v2.env` and harvest
+# the credentials.
+#
+# After this:
+#   Administrators : Full control (operators editing config)
+#   SYSTEM         : Full control (services run as LocalSystem by default)
+#   <nobody else>  : no access
+#
+# Logs and backup dirs stay user-readable/writable (no secrets there).
+Log "Hardening config dir ACL: $ConfigDir"
+$null = & icacls.exe $ConfigDir /inheritance:r /Q 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "icacls /inheritance:r failed (exit $LASTEXITCODE) — config dir may still allow Users:read"
+}
+$null = & icacls.exe $ConfigDir /grant:r 'Administrators:(OI)(CI)F' /Q 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "icacls grant Administrators failed (exit $LASTEXITCODE)"
+}
+$null = & icacls.exe $ConfigDir /grant:r 'SYSTEM:(OI)(CI)F' /Q 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "icacls grant SYSTEM failed (exit $LASTEXITCODE)"
+}
+
 # 3. Local Operators group — create-if-missing, idempotent.
 if (-not (Group-Exists $OperatorGroup)) {
     Log "Creating local group: $OperatorGroup"

--- a/installer/install-services.ps1
+++ b/installer/install-services.ps1
@@ -257,21 +257,42 @@ Install-NssmService $ServiceApi    $ApiExe
 Install-NssmService $ServiceDaemon $DaemonExe
 
 # 6. Apply / re-apply NSSM params for both services.
-function Set-NssmParams($name, $appDir, $logBase, $env, $depends) {
-    & $NssmExe set $name AppDirectory       $appDir         | Out-Null
-    & $NssmExe set $name AppStdout          "$LogDir\$logBase.out.log" | Out-Null
-    & $NssmExe set $name AppStderr          "$LogDir\$logBase.err.log" | Out-Null
-    & $NssmExe set $name AppRotateFiles     1               | Out-Null
-    & $NssmExe set $name AppRotateBytes     10485760        | Out-Null
-    & $NssmExe set $name AppEnvironmentExtra "WINSERVERRAG_CONFIG_DIR=$ConfigDir" | Out-Null
-    & $NssmExe set $name Start              SERVICE_AUTO_START | Out-Null
+#
+# v1.3.2: stopTimeoutMs param. NSSM's default stop sequence is
+# Console (1.5s) → Window (1.5s) → Threads (1.5s) → Process kill ≈ 4.5s.
+# The daemon needs much longer to drain in-flight workers (PDF extract,
+# embedding batch, DB commit can take 10-30s each). Without this, NSSM
+# TerminateProcess's the daemon mid-task → stale worker rows in PG,
+# leaked advisory locks, half-committed builds.
+#
+# stopTimeoutMs is the Console (Ctrl+C / SIGBREAK) budget. We give 30s
+# to daemon, 5s to API (the FastAPI lifespan unwinds quickly). Window /
+# Threads phases stay short (5s each) — by the time we're there, the
+# graceful path failed and we want to escalate.
+function Set-NssmParams($name, $appDir, $logBase, $env, $depends, $stopTimeoutMs) {
+    & $NssmExe set $name AppDirectory       $appDir         *>$null
+    & $NssmExe set $name AppStdout          "$LogDir\$logBase.out.log" *>$null
+    & $NssmExe set $name AppStderr          "$LogDir\$logBase.err.log" *>$null
+    & $NssmExe set $name AppRotateFiles     1               *>$null
+    & $NssmExe set $name AppRotateBytes     10485760        *>$null
+    & $NssmExe set $name AppRotateOnline    1               *>$null  # rotate without restart
+    & $NssmExe set $name AppEnvironmentExtra "WINSERVERRAG_CONFIG_DIR=$ConfigDir" *>$null
+    & $NssmExe set $name Start              SERVICE_AUTO_START *>$null
+    # Stop sequence — graceful shutdown budget.
+    & $NssmExe set $name AppStopMethodSkip    0          *>$null  # try all 4 phases
+    & $NssmExe set $name AppStopMethodConsole $stopTimeoutMs *>$null
+    & $NssmExe set $name AppStopMethodWindow  5000       *>$null
+    & $NssmExe set $name AppStopMethodThreads 5000       *>$null
+    & $NssmExe set $name AppKillProcessTree   1          *>$null  # kill children with main
     if ($depends) {
-        & $NssmExe set $name DependOnService $depends | Out-Null
+        & $NssmExe set $name DependOnService $depends *>$null
     }
 }
 
-Set-NssmParams $ServiceApi    (Split-Path $ApiExe)    "api"    $ConfigDir $null
-Set-NssmParams $ServiceDaemon (Split-Path $DaemonExe) "daemon" $ConfigDir $ServiceApi
+# API: 5s console budget (FastAPI lifespan unwinds fast).
+# Daemon: 30s console budget (workers may be mid-PDF / mid-embedding).
+Set-NssmParams $ServiceApi    (Split-Path $ApiExe)    "api"    $ConfigDir $null         5000
+Set-NssmParams $ServiceDaemon (Split-Path $DaemonExe) "daemon" $ConfigDir $ServiceApi  30000
 
 # 7. Set descriptions (cosmetic, services.msc).
 & $NssmExe set $ServiceApi    Description "WinServerRAG control API + web monitor (FastAPI on :17600)" | Out-Null

--- a/src/config.py
+++ b/src/config.py
@@ -9,11 +9,35 @@ import sys
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# v1.3.2: honor the WINSERVERRAG_CONFIG_DIR env var that the installer
+# (installer/install-services.ps1) sets via NSSM AppEnvironmentExtra.
+# Without this, a PyInstaller-bundled service resolves PROJECT_ROOT to
+# its frozen bundle root (e.g. C:\Program Files\WinServerRAG\bin\
+# winserverrag-daemon\_internal\) and never finds the operator's
+# config at %ProgramData%\WinServerRAG\config\config.v2.env. The
+# service exits 1 with "no config.env found" and NSSM crash-loops it.
+#
+# Fallback chain:
+#   1) WINSERVERRAG_CONFIG_DIR env var (production: set by installer)
+#   2) PROJECT_ROOT/config/                (dev: running from repo)
+#
+# DATA_ROOT is derived from CONFIG_DIR's parent so logs/lock dirs land
+# next to config under %ProgramData%\WinServerRAG\ instead of inside
+# the read-only Program Files bundle.
+_env_config_dir = os.environ.get("WINSERVERRAG_CONFIG_DIR")
+if _env_config_dir:
+    CONFIG_DIR = Path(_env_config_dir).resolve()
+    DATA_ROOT = CONFIG_DIR.parent
+else:
+    CONFIG_DIR = PROJECT_ROOT / "config"
+    DATA_ROOT = PROJECT_ROOT
+
 # Config path lookup: prefer the versioned v2 file, fall back to legacy.
 # Both are tried in order; the first that exists is loaded.
 CONFIG_PATH_CANDIDATES = [
-    PROJECT_ROOT / "config" / "config.v2.env",
-    PROJECT_ROOT / "config" / "config.env",
+    CONFIG_DIR / "config.v2.env",
+    CONFIG_DIR / "config.env",
 ]
 CONFIG_PATH: Path | None = None  # set by load_config()
 
@@ -74,7 +98,23 @@ def _env_float(name: str, default: float) -> float:
 GOOGLE_EMAIL = _env("GOOGLE_EMAIL")
 GOOGLE_CLIENT_ID = _env("GOOGLE_OAUTH_CLIENT_ID")
 GOOGLE_CLIENT_SECRET = _env("GOOGLE_OAUTH_CLIENT_SECRET")
-TOKEN_PATH = PROJECT_ROOT / _env("GOOGLE_TOKEN_PATH", "config/token.pickle")
+# Token path resolution. Three forms supported:
+#   1) Absolute path → used as-is
+#   2) Legacy "config/foo" prefix → resolved under DATA_ROOT (= repo
+#      root in dev, %ProgramData%\WinServerRAG in prod). Backward compat
+#      for installs whose config.v2.env carries the pre-v1.3.2 default.
+#   3) Plain relative → resolved under CONFIG_DIR (alongside config.v2.env)
+#
+# Pre-v1.3.2 always used PROJECT_ROOT, which broke installed services
+# (PyInstaller bundle = read-only Program Files subtree).
+_token_setting = _env("GOOGLE_TOKEN_PATH", "token.pickle")
+_token_path = Path(_token_setting)
+if _token_path.is_absolute():
+    TOKEN_PATH = _token_path
+elif _token_setting.replace("\\", "/").startswith("config/"):
+    TOKEN_PATH = DATA_ROOT / _token_setting
+else:
+    TOKEN_PATH = CONFIG_DIR / _token_setting
 
 # --- PostgreSQL ---
 PG_HOST = _env("PGHOST", "localhost")
@@ -122,7 +162,11 @@ API_PORT = _env_int("API_PORT", 17600)
 API_BEARER_TOKEN = _env("API_BEARER_TOKEN", "")
 
 # --- Derived paths ---
-LOGS_DIR = PROJECT_ROOT / "logs"
-LOGS_DIR.mkdir(exist_ok=True)
-LOCK_DIR = PROJECT_ROOT / "run"
-LOCK_DIR.mkdir(exist_ok=True)
+# In production these resolve under %ProgramData%\WinServerRAG\
+# (created by the installer with users-modify perms). In dev they
+# resolve next to the repo. parents=True so a fresh ProgramData layout
+# without a pre-created run\ directory still works.
+LOGS_DIR = DATA_ROOT / "logs"
+LOGS_DIR.mkdir(parents=True, exist_ok=True)
+LOCK_DIR = DATA_ROOT / "run"
+LOCK_DIR.mkdir(parents=True, exist_ok=True)

--- a/src/rag_daemon.py
+++ b/src/rag_daemon.py
@@ -662,6 +662,18 @@ def main() -> int:
         signal.signal(signal.SIGTERM, _signal_handler)
     except (ValueError, AttributeError):
         pass
+    # NSSM's AppStopMethodConsole = 1 (default) sends CTRL_BREAK_EVENT,
+    # not CTRL_C_EVENT. On Windows, Python translates that to SIGBREAK,
+    # not SIGINT. Without this handler, NSSM's graceful-stop signal is
+    # silently dropped and the daemon only exits when NSSM escalates to
+    # CTRL_C_EVENT or TerminateProcess. Pair with the 30s
+    # AppStopMethodConsole timeout configured in install-services.ps1.
+    sigbreak = getattr(signal, "SIGBREAK", None)
+    if sigbreak is not None:
+        try:
+            signal.signal(sigbreak, _signal_handler)
+        except (ValueError, AttributeError):
+            pass
 
     try:
         lock = Lock(LOCK_PATH, stale_after_sec=1800)


### PR DESCRIPTION
## Summary

直近のインストーラー連鎖バグ (PR #34/35/36/37) のポストモーテムから抽出した防御層 + Codex 独立レビューで判明した P0/P1 を **7件まとめて** 塞ぐ。

| # | Severity | What |
|---|----------|------|
| F1 | P1 | Inno Setup [Run] が install-services.ps1 の exit code を見ない silent failure |
| F2 | P1 | NSSM stop timeout 4.5s では daemon が drain しきれない |
| F3 | P1 | Inno [Code] の `Exec()` 戻り値チェック漏れ |
| F4 | P2 | Electron renderer クラッシュ未捕捉 (main は PR #35 済) |
| F8 | P2 | `rag_daemon.py` が SIGBREAK 未ハンドル (NSSM Ctrl+Break) |
| **C1** | **P0** | **`src/config.py` が `WINSERVERRAG_CONFIG_DIR` env var を読まない → サービス全滅** |
| **C4** | **P1** | **`%ProgramData%\WinServerRAG\config` が全ユーザー read 可、PG password / OAuth secret 漏洩** |

C1/C4 は Codex 独立レビューで発見。前者は PR #37 が直って install が通った瞬間に services が config not found で死ぬ "next failure" 級のバグ。後者は機密漏洩。

## C1: WINSERVERRAG_CONFIG_DIR を Python が読む

`installer/install-services.ps1` は NSSM の `AppEnvironmentExtra` でこの env var を設定済。だが `src/config.py:14` は `PROJECT_ROOT/config/` だけを見ていた。PyInstaller bundle で `__file__` は `C:\Program Files\WinServerRAG\bin\winserverrag-daemon\_internal\src\config.py` を指す → `_internal/config/config.v2.env` は存在しない → `sys.exit(1)`。

**dev ではバグが見えない** (リポジトリの `config/` を見ているから)。PR #34-37 で install 経路が直って初めて発火する次のバグ。

修正:
```python
_env_config_dir = os.environ.get("WINSERVERRAG_CONFIG_DIR")
if _env_config_dir:
    CONFIG_DIR = Path(_env_config_dir).resolve()
    DATA_ROOT = CONFIG_DIR.parent
else:
    CONFIG_DIR = PROJECT_ROOT / "config"
    DATA_ROOT = PROJECT_ROOT

CONFIG_PATH_CANDIDATES = [CONFIG_DIR / "config.v2.env", CONFIG_DIR / "config.env"]
```

`TOKEN_PATH` / `LOGS_DIR` / `LOCK_DIR` も `DATA_ROOT` 配下に再アンカー。legacy `config/token.pickle` 設定も `DATA_ROOT` 相対として尊重 (backward compat)。

## C4: config dir を admin-only に lockdown

`%ProgramData%` は Authenticated Users に read を継承で渡すデフォルト。Inno Setup の `Permissions` は ACE を**追加**するだけで継承を破らない。つまり `users-readexec` を外しても、Authenticated Users は依然読める。

修正: `install-services.ps1` 新規 step 2.5 で:
```powershell
icacls $ConfigDir /inheritance:r
icacls $ConfigDir /grant:r 'Administrators:(OI)(CI)F'
icacls $ConfigDir /grant:r 'SYSTEM:(OI)(CI)F'
```
継承を切って Administrators + SYSTEM のみ Full に。logs / backups は `users-modify` のまま (機密無し)。

Inno `[Dirs]` config エントリも `admins-full` に揃える。

## F1-F4 + F8 (詳細は前 commit 参照)

- **F1**: `CurStepChanged(ssPostInstall)` で `install-services-FAILED.txt` を読んで MsgBox
- **F2**: NSSM `AppStopMethodConsole=30000` (daemon) / `5000` (API) + `AppKillProcessTree=1` + `AppRotateOnline=1`
- **F3**: Inno `[Code]` `Exec()` bool 戻り値チェック
- **F4**: Electron `webContents.on('render-process-gone')` + `win.on('unresponsive')`
- **F8**: `rag_daemon.py` に SIGBREAK ハンドラ

## Test plan

- [ ] CI lint / Analyze Python / CodeQL すべて pass
- [ ] CI installer build → `WinServerRAG-Setup-1.3.0.exe`
- [ ] **Fresh install + service start**: `Get-Service WinServerRAG-API,WinServerRAG-Daemon` が両方 Running、daemon の log に "config loaded from: %ProgramData%\WinServerRAG\config\config.v2.env"
- [ ] **C4 検証**: 非管理者アカウントから `type %ProgramData%\WinServerRAG\config\config.v2.env` → "アクセスが拒否されました"
- [ ] **upgrade install**: 既存 v1.3.0 → 新 v1.3.0 へ上書き、サービス停止→ファイル更新→サービス再登録 がスムーズ
- [ ] **F2 検証**: 大きな drive を sync 中に `sc stop WinServerRAG-Daemon` → 30秒以内に graceful 停止、log に "signal SIGBREAK received, draining..." → worker rows cleanup
- [ ] **F1 検証**: 故意に install-services.ps1 を壊す (例: nssm.exe を rename) → install 完走後に MsgBox 表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)