### PR TITLE
fix(installer,ci): copy REAL nssm.exe, not Chocolatey shim — root cause of v1.3.0 install chain

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -85,20 +85,64 @@ jobs:
 
       - name: Install NSSM via choco (cached)
         shell: pwsh
-        # nssm.cc has been flaky (503s). Choco mirror is reliable. The
-        # installer/build.ps1 will pick up nssm.exe from the choco-installed
-        # location via its winget-cache probe (we drop a copy at the
-        # expected path below).
+        # nssm.cc has been flaky (503s). Choco mirror is reliable.
+        #
+        # CRITICAL: `Get-Command nssm` returns Chocolatey's SHIM at
+        # C:\ProgramData\chocolatey\bin\nssm.exe. The shim is a tiny
+        # (~60KB) wrapper that delegates to the real binary at
+        # C:\ProgramData\chocolatey\lib\NSSM\tools\win64\nssm.exe at
+        # runtime. If we copy the SHIM into the installer, it ends up
+        # at C:\Program Files\WinServerRAG\bin\nssm.exe and tries to
+        # find ..\lib\NSSM\tools\nssm.exe — which doesn't exist on the
+        # operator's machine. Result: every `nssm install` and
+        # `nssm set` returns exit -1, services never register.
+        #
+        # This was the root cause of the v1.3.0 install failure chain.
+        # The Group-Exists / NativeCommandError fixes (PR #37, #41)
+        # were real bugs but downstream symptoms — install would have
+        # failed at the next nssm call regardless.
+        #
+        # Fix: copy the REAL nssm.exe from the choco lib subtree.
+        # Verify size > 200KB (real nssm-2.24 win64 is ~370KB; shim
+        # is ~60KB) so a future packaging change doesn't silently
+        # regress.
         run: |
           choco install nssm --no-progress --yes
-          $nssm = (Get-Command nssm -ErrorAction SilentlyContinue).Source
+          $candidates = @(
+            "C:\ProgramData\chocolatey\lib\NSSM\tools\win64\nssm.exe",
+            "C:\ProgramData\chocolatey\lib.installed\NSSM\tools\win64\nssm.exe"
+          )
+          $nssm = $null
+          foreach ($p in $candidates) {
+            if (Test-Path $p) { $nssm = $p; break }
+          }
           if (-not $nssm) {
-            Write-Error "nssm not found after install"
+            # Last-resort scan
+            $nssm = Get-ChildItem -Path "C:\ProgramData\chocolatey" -Recurse `
+              -Filter "nssm.exe" -ErrorAction SilentlyContinue |
+              Where-Object { $_.FullName -match "win64" -and $_.Length -gt 200000 } |
+              Select-Object -First 1 -ExpandProperty FullName
+          }
+          if (-not $nssm) {
+            Write-Error "Real nssm.exe not found in choco lib subtree"
+            exit 1
+          }
+          $size = (Get-Item $nssm).Length
+          if ($size -lt 200000) {
+            Write-Error "nssm.exe at $nssm is only $size bytes — likely a shim, not the real binary"
+            exit 1
+          }
+          # Verify it's not a shim by checking VersionInfo. The shim has
+          # FileDescription containing "Chocolatey Shim". Real nssm
+          # has FileDescription "the Non-Sucking Service Manager".
+          $vi = (Get-Item $nssm).VersionInfo.FileDescription
+          if ($vi -match "Shim") {
+            Write-Error "nssm.exe at $nssm is a Chocolatey shim ($vi). Use the real binary."
             exit 1
           }
           New-Item -ItemType Directory -Force -Path "installer/inno/assets" | Out-Null
           Copy-Item -Force $nssm "installer/inno/assets/nssm.exe"
-          Write-Host "Copied $nssm -> installer/inno/assets/nssm.exe"
+          Write-Host "Copied REAL nssm.exe ($size bytes, '$vi') from $nssm"
 
       - name: Resolve version
         id: ver

--- a/installer/install-services.ps1
+++ b/installer/install-services.ps1
@@ -198,6 +198,19 @@ foreach ($p in @($NssmExe, $ApiExe, $DaemonExe)) {
     }
 }
 
+# 1.0a v1.3.2: detect Chocolatey shim masquerading as nssm.exe.
+# The shim (~60KB) delegates to a real binary in choco's lib subtree
+# that doesn't exist on the operator's machine — every nssm call would
+# return exit -1 with "Cannot find file at '..\lib\NSSM\tools\...'".
+# Real nssm.exe 2.24 win64 is ~370KB. If we ever ship a shim again,
+# this throws fast with a clear message instead of failing mid-install.
+$nssmSize = (Get-Item $NssmExe).Length
+$nssmDesc = (Get-Item $NssmExe).VersionInfo.FileDescription
+if ($nssmSize -lt 200000 -or $nssmDesc -match "Shim") {
+    throw "nssm.exe at $NssmExe looks like a Chocolatey shim (size=$nssmSize, desc='$nssmDesc'). Real nssm-2.24 win64 is ~370KB and FileDescription does NOT contain 'Shim'. The CI workflow's `Install NSSM via choco` step is supposed to copy the REAL binary from C:\ProgramData\chocolatey\lib\NSSM\tools\win64\nssm.exe, not the shim from C:\ProgramData\chocolatey\bin\nssm.exe. Re-build the installer."
+}
+Log "nssm.exe verified ($nssmSize bytes, '$nssmDesc')"
+
 # 1.1 v1.3.2: clear any stale FAILED.txt sentinel from a prior install.
 # Inno Setup's CurStepChanged hook checks for this file's presence (NOT
 # its age — Inno Pascal Script doesn't expose FileAge). Removing it


### PR DESCRIPTION
## 真の root cause 発見

実機 deployed の install で nssm を手動実行 → **nssm.exe は本物ではなく Chocolatey の shim だった**。

```
C:\Program Files\WinServerRAG\bin\nssm.exe (60928 bytes)
Cannot find file at '..\\lib\NSSM\tools\nssm.exe'
    (C:\Program Files\WinServerRAG\lib\NSSM\tools\nssm.exe).
exit=-1
```

choco の shim は ~60KB の薄いラッパーで、実行時に `..\lib\NSSM\tools\` 相対パスで本物を呼び出す。インストーラーで `C:\Program Files\WinServerRAG\bin\nssm.exe` にコピーすると、shim は `C:\Program Files\WinServerRAG\lib\NSSM\tools\nssm.exe` を探し → 当然存在せず → `exit=-1`。

## 連鎖の全貌

PR #34/#37/#41 で直した PowerShell stderr バグ群 (Group-Exists で throw 等) は **本物のバグだったが、症状の連鎖の上層**。下層では nssm shim が常に exit -1 を返していて、Group-Exists を直しても次の `nssm install` で必ず死ぬ運命だった。

shim が **load-bearing failure** 全部の根本原因。これを直さない限り何度直しても install は通らない。

## Fix

### `.github/workflows/installer.yml`

```yaml
$candidates = @(
  "C:\ProgramData\chocolatey\lib\NSSM\tools\win64\nssm.exe",
  "C:\ProgramData\chocolatey\lib.installed\NSSM\tools\win64\nssm.exe"
)
foreach ($p in $candidates) { if (Test-Path $p) { $nssm = $p; break } }
# size > 200KB + FileDescription does NOT contain 'Shim' を確認
```

`Get-Command nssm` (= shim) の代わりに choco の lib subtree から本物を引く + サイズ + VersionInfo で shim 検知。将来 shim が混入したら **build を loud に fail** する。

### `installer/install-services.ps1` step 1.0a (defense-in-depth)

インストール時に nssm.exe のサイズ + FileDescription を pre-flight check。shim が混じってたら fast fail with clear message。将来また packaging regression があっても 'nssm.exe at X looks like a Chocolatey shim' と直接言う。

## 期待結果

PR #41 の Invoke-Native は正しい修正 → 残る。
本 PR で nssm 本物が同梱される → `nssm install` が普通に通る。
**今度こそ services が register される**。
