### PR TITLE
fix(mini,wizard): plan-eng-review findings B1-B13 (P0 lock + 6 more)

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -177,9 +177,9 @@
         <span id="indicator" class="indicator"><span class="core"></span></span>
         WinServerRAG
       </h1>
-      <button id="pause-btn" class="pause-btn" title="サービスを一時停止 / 再開 (新規タスク取得を止める。進行中タスクは完走)">⏸</button>
-      <button id="open-btn" class="header-btn" title="ブラウザでフル Monitor を開く">Monitor を開く</button>
-      <input type="checkbox" id="aot-toggle" class="aot-toggle" title="常に最前面に表示">
+      <button id="pause-btn" class="pause-btn" title="サービスを一時停止 / 再開 (新規タスク取得を止める。進行中タスクは完走)" aria-label="一時停止または再開">⏸</button>
+      <button id="open-btn" class="header-btn" title="ブラウザでフル Monitor を開く" aria-label="Web Console を開く">Monitor を開く</button>
+      <input type="checkbox" id="aot-toggle" class="aot-toggle" title="常に最前面に表示" aria-label="常に最前面に表示">
     </div>
     <div class="topbar">
       <div id="progress-agg" class="progress-agg"><div class="fill" id="progress-fill" style="width:0"></div></div>
@@ -202,7 +202,7 @@
     <div id="cfg-cta" class="cfg-cta">
       <div class="title" id="cfg-cta-title">⚠ config 設定を行ってください</div>
       <div class="detail" id="cfg-cta-detail">config.v2.env が未作成です。Setup Wizard を実行して PostgreSQL / Google OAuth を設定してください。</div>
-      <button id="cfg-cta-btn">Setup Wizard を起動</button>
+      <button id="cfg-cta-btn" aria-label="Setup Wizard を起動して config を作成">Setup Wizard を起動</button>
     </div>
     <div class="rows">
       <!-- High-priority operator-facing status — at the very top so it's the

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -70,10 +70,25 @@ function detectMode() {
 
 const MODE = detectMode();
 
-// Single-instance lock: prevent two Mini Monitors. Wizard is allowed
-// to coexist with Mini (different UI). The lock key includes the mode.
-const lockKey = `winserverrag-${MODE}`;
-const gotLock = app.requestSingleInstanceLock({ key: lockKey });
+// v1.3.2 fix B1: split userData by mode so Mini and Wizard don't share
+// the single-instance lock.
+//
+// Why: requestSingleInstanceLock(additionalData?) — the argument is NOT
+// a lock key, it's data passed to the second-instance event handler.
+// The actual lock is per-app, derived from app.name × userData dir.
+// Mini.exe and Setup.exe (a renamed copy of Mini.exe) share both, so
+// they share the lock. Result: clicking the Mini Monitor's "Setup
+// Wizard を起動" CTA spawns Setup.exe, which fails the lock check
+// while Mini holds it, and silently quits. Wizard never opens.
+//
+// Fix: change userData per mode BEFORE requestSingleInstanceLock. Each
+// mode now has its own SingletonLock file, so they coexist.
+if (MODE === "wizard") {
+  const wizardData = path.join(app.getPath("appData"), "WinServerRAG-Wizard");
+  app.setPath("userData", wizardData);
+}
+
+const gotLock = app.requestSingleInstanceLock();
 if (!gotLock) {
   console.log(`[main] another ${MODE} instance is already running, exiting.`);
   app.quit();
@@ -121,7 +136,8 @@ function createMiniWindow() {
       dialog.showErrorBox(
         "WinServerRAG Mini — Renderer crashed",
         `Reason: ${details.reason}\nExit code: ${details.exitCode}\n\n` +
-        "The mini-monitor will exit. Re-launch from the Start Menu."
+        "The mini-monitor will exit. Re-launch from the Start Menu shortcut\n" +
+        '"WinServerRAG Mini Monitor".'
       );
     } catch {}
     app.exit(3);

--- a/desktop/preload-wizard.js
+++ b/desktop/preload-wizard.js
@@ -18,9 +18,18 @@ contextBridge.exposeInMainWorld("wizard", {
   // Apply: write config.v2.env atomically
   writeConfig:       (values) => ipcRenderer.invoke("wizard:write-config", values),
 
-  // db_init — spawn winserverrag-dbinit.exe and stream output
+  // db_init — spawn winserverrag-dbinit.exe and stream output.
+  // v1.3.2 fix B3: onDbInitLog returns an `off()` disposer so the
+  // wizard renderer can detach the listener when the user navigates
+  // away from step 6 (or re-runs db_init). Without this, every
+  // re-entry into step 6 attaches another listener and log lines
+  // duplicate N times after N re-runs.
   runDbInit:         () => ipcRenderer.invoke("wizard:db-init"),
-  onDbInitLog:       (cb) => ipcRenderer.on("wizard:db-init-log", (_e, line) => cb(line)),
+  onDbInitLog:       (cb) => {
+    const handler = (_e, line) => cb(line);
+    ipcRenderer.on("wizard:db-init-log", handler);
+    return () => ipcRenderer.removeListener("wizard:db-init-log", handler);
+  },
 
   // Service start
   startServices:     () => ipcRenderer.invoke("wizard:start-services"),

--- a/desktop/wizard-ipc.js
+++ b/desktop/wizard-ipc.js
@@ -90,9 +90,17 @@ async function prereqCheck() {
 function testPgConnection(params) {
   const { host, port, user, password, database } = params || {};
   return new Promise((resolve) => {
-    // Build a temporary env so we don't leak the password into argv.
+    // v1.3.2 fix B8: minimal env to the child. Forwarding the full
+    // process.env leaks anything the wizard process picked up
+    // (WINSERVERRAG_API_BEARER_TOKEN if set, OAuth tokens, etc.).
+    // psql only needs PG* vars + SystemRoot/Path for DLL resolution
+    // on Windows.
     const env = {
-      ...process.env,
+      SystemRoot: process.env.SystemRoot || "C:\\Windows",
+      PATH: process.env.PATH || process.env.Path || "",
+      Path: process.env.Path || process.env.PATH || "",
+      TEMP: process.env.TEMP || process.env.TMP || "C:\\Windows\\Temp",
+      TMP:  process.env.TMP  || process.env.TEMP || "C:\\Windows\\Temp",
       PGHOST: host || "localhost",
       PGPORT: port || "5432",
       PGUSER: user || "postgres",
@@ -138,9 +146,42 @@ async function pickCredentials() {
   return { canceled: false, path: r.filePaths[0] };
 }
 
+// v1.3.2 fix B6: sanity-check the source path before copying. The
+// renderer SHOULD only ever pass a path returned by pickCredentials
+// (which is the Electron file dialog), but contextIsolation is
+// defense-in-depth, not a guarantee — a future preload regression or
+// devtools console call could pass any path. Reject anything that
+// isn't a JSON file under a reasonable size.
+const MAX_CREDENTIALS_BYTES = 32 * 1024; // 32KB; real OAuth client.json is ~500B
+
 function copyCredentials(srcPath) {
   return new Promise((resolve) => {
     try {
+      if (typeof srcPath !== "string" || srcPath.length === 0) {
+        return resolve({ ok: false, error: "invalid path" });
+      }
+      const ext = path.extname(srcPath).toLowerCase();
+      if (ext !== ".json") {
+        return resolve({ ok: false, error: `expected a .json file, got ${ext || "(no ext)"}` });
+      }
+      const stat = fs.statSync(srcPath);
+      if (!stat.isFile()) {
+        return resolve({ ok: false, error: "source is not a regular file" });
+      }
+      if (stat.size > MAX_CREDENTIALS_BYTES) {
+        return resolve({ ok: false, error: `file too large (${stat.size} bytes, max ${MAX_CREDENTIALS_BYTES})` });
+      }
+      // Light schema check: real Google OAuth credentials.json has
+      // an "installed" or "web" top-level key with "client_id" inside.
+      const text = fs.readFileSync(srcPath, "utf-8");
+      let obj;
+      try { obj = JSON.parse(text); } catch {
+        return resolve({ ok: false, error: "file is not valid JSON" });
+      }
+      const root = obj && (obj.installed || obj.web);
+      if (!root || typeof root.client_id !== "string") {
+        return resolve({ ok: false, error: "JSON does not look like a Google OAuth credentials file (missing installed/web → client_id)" });
+      }
       const dst = path.join(_ctx.configCheck.configDir(), "credentials.json");
       fs.mkdirSync(path.dirname(dst), { recursive: true });
       fs.copyFileSync(srcPath, dst);
@@ -233,7 +274,19 @@ function register(ctx) {
   const { ipcMain, app } = ctx;
   const { shell } = require("electron");
 
-  ipcMain.handle("wizard:read-config",   () => ctx.configCheck.checkConfig());
+  // v1.3.2 fix B4: include the parsed values so the wizard can
+  // pre-fill its forms on re-run. checkConfig() alone returns only
+  // status — without values, every re-run resets to defaults and
+  // the operator types their PG password again. Returns:
+  //   { kind, missingKeys?, placeholderKeys?, path, values }
+  // where values is the parsed {key: value} dict (empty {} if no
+  // file). missingKeys / placeholderKeys are still populated by
+  // validateConfig for the CTA logic.
+  ipcMain.handle("wizard:read-config",   () => {
+    const status = ctx.configCheck.checkConfig();
+    const parsed = ctx.configCheck.readConfig();
+    return { ...status, values: (parsed && parsed.values) || {} };
+  });
   ipcMain.handle("wizard:config-path",   () => ctx.configCheck.configPath());
   ipcMain.handle("wizard:prereq-check",  () => prereqCheck());
   ipcMain.handle("wizard:pg-test",       (_e, params) => testPgConnection(params));

--- a/desktop/wizard.js
+++ b/desktop/wizard.js
@@ -80,18 +80,21 @@ const steps = [
       setBack(false);
       setStatus("既存の設定を読み込み中...", null);
       const existing = await W.readConfig();
-      // Pre-fill state from existing config (read-side; won't overwrite
-      // until step 6 writes).
-      if (existing && existing.kind !== "missing_file") {
-        try {
-          const path = await W.configPath();
-          // configCheck.checkConfig only returns status, not the full
-          // values. Re-fetch via readConfig for the values. Hmm — our
-          // IPC currently only exposes checkConfig. For the wizard we
-          // want the values. Let's just leave defaults; user enters
-          // values fresh. Future: extend IPC to expose values.
-          STATE.existing_status = existing;
-        } catch {}
+      // v1.3.2 fix B4: pre-fill STATE from existing config values so
+      // wizard re-run doesn't erase the operator's prior input.
+      // Each group merges only the keys it cares about; unknown keys
+      // are ignored. Empty/blank values fall through to defaults.
+      if (existing && existing.values) {
+        const v = existing.values;
+        const m = (group, keys) => {
+          for (const k of keys) {
+            if (v[k] !== undefined && v[k] !== "") group[k] = v[k];
+          }
+        };
+        m(STATE.google,   ["GOOGLE_EMAIL", "GOOGLE_OAUTH_CLIENT_ID", "GOOGLE_OAUTH_CLIENT_SECRET", "GOOGLE_TOKEN_PATH"]);
+        m(STATE.postgres, ["PGHOST", "PGPORT", "PGUSER", "PGPASSWORD", "PGDATABASE"]);
+        m(STATE.indexing, ["EMBEDDING_MODEL", "EMBEDDING_DEVICE", "BATCH_SIZE", "DAEMON_WORKER_THREADS"]);
+        m(STATE.api,      ["API_HOST", "API_PORT", "API_BEARER_TOKEN"]);
       }
       setStatus("");
       $("step-host").innerHTML = `
@@ -384,22 +387,28 @@ const steps = [
         box.appendChild(div);
         box.scrollTop = box.scrollHeight;
       };
-      // Subscribe to the log stream BEFORE invoking
-      W.onDbInitLog((line) => append(line));
+      // v1.3.2 fix B3: capture the off() disposer so re-runs don't
+      // accumulate listeners. We detach BEFORE returning regardless
+      // of success/fail. Subsequent runs start with a fresh listener.
+      const offLog = W.onDbInitLog((line) => append(line));
       setStatus("db_init 実行中...", null);
       setNext("実行中...", false);
-      const r = await W.runDbInit();
-      STATE.dbInitResult = r;
-      if (r.ok) {
-        append("--- 完了 (exit 0) ---", "ok");
-        setStatus("db_init 完了", "ok");
-        setNext("次へ", true);
-        return true;
-      } else {
-        append(`--- 失敗 (exit ${r.exitCode}): ${r.error || ""} ---`, "err");
-        setStatus("db_init 失敗", "err");
-        setNext("再実行", true);
-        return "stay";
+      try {
+        const r = await W.runDbInit();
+        STATE.dbInitResult = r;
+        if (r.ok) {
+          append("--- 完了 (exit 0) ---", "ok");
+          setStatus("db_init 完了", "ok");
+          setNext("次へ", true);
+          return true;
+        } else {
+          append(`--- 失敗 (exit ${r.exitCode}): ${r.error || ""} ---`, "err");
+          setStatus("db_init 失敗", "err");
+          setNext("再実行", true);
+          return "stay";
+        }
+      } finally {
+        try { if (typeof offLog === "function") offLog(); } catch {}
       }
     },
   },
@@ -513,25 +522,60 @@ async function go() {
   await steps[stepIdx].render();
 }
 
+// v1.3.2 fix B5: snapshot the current step's form values before any
+// transition (Back or Next). Without this, hitting Back after typing
+// a PG password (step 2) loses the input. Only steps with collect*
+// helpers participate; others are no-op.
+function snapshotCurrentStep() {
+  try {
+    if (stepIdx === 2 && document.getElementById("pg-host")) {
+      Object.assign(STATE.postgres, collectPg());
+    }
+    if (stepIdx === 3 && document.getElementById("g-email")) {
+      STATE.google.GOOGLE_EMAIL = $("g-email").value.trim();
+      STATE.google.GOOGLE_OAUTH_CLIENT_ID = $("g-cid").value.trim();
+      STATE.google.GOOGLE_OAUTH_CLIENT_SECRET = $("g-csec").value;
+    }
+    if (stepIdx === 4 && document.getElementById("ix-model")) {
+      STATE.indexing.EMBEDDING_MODEL = $("ix-model").value.trim();
+      STATE.indexing.EMBEDDING_DEVICE = $("ix-device").value;
+      STATE.indexing.BATCH_SIZE = $("ix-batch").value || "64";
+      STATE.indexing.DAEMON_WORKER_THREADS = $("ix-threads").value || "4";
+    }
+  } catch {
+    // DOM not ready / element missing — best-effort snapshot only.
+  }
+}
+
 // ---------------------------------------------------------------------
 // Wire-up
 // ---------------------------------------------------------------------
+// v1.3.2 fix B2: inflight guard. Without this, Back fires while
+// onNext (e.g. db_init child process running in step 6) is in flight,
+// state machine corrupts: stepIdx changes mid-await, the resolving
+// onNext writes to elements from a stale step.
+let _busyOnNext = false;
+
 window.addEventListener("DOMContentLoaded", () => {
   $("back").addEventListener("click", () => {
-    if (stepIdx > 0) {
-      stepIdx--;
-      go();
-    }
+    if (_busyOnNext || stepIdx === 0) return;
+    snapshotCurrentStep();
+    stepIdx--;
+    go();
   });
   $("next").addEventListener("click", async () => {
-    const result = await steps[stepIdx].onNext();
-    if (result === true) {
-      if (stepIdx < TOTAL_STEPS - 1) {
+    if (_busyOnNext) return;
+    _busyOnNext = true;
+    try {
+      const result = await steps[stepIdx].onNext();
+      if (result === true && stepIdx < TOTAL_STEPS - 1) {
         stepIdx++;
         go();
       }
+      // result === "stay" → render didn't change, status already set
+    } finally {
+      _busyOnNext = false;
     }
-    // result === "stay" → render didn't change, status already set
   });
   go();
 });


### PR DESCRIPTION
## Summary

`/plan-eng-review` で発見した Mini Monitor + Setup Wizard の bug 7 件 (P0×1 / P1×1 / P2×4 / P3×3) を 1 PR で修正。

| # | Severity | What |
|---|----------|------|
| **B1** | **P0** | `requestSingleInstanceLock({key})` が無効 → Mini/Wizard 共存できず |
| **B2** | **P1** | Back during db_init で state machine 崩壊 |
| **B3** | P2 | db_init ログ listener leak、再実行で行重複 |
| **B4** | P2 | `wizard:read-config` が values 返さず pre-fill 不能 |
| **B5** | P2 | Back 遷移で入力消失 |
| **B6** | P2 | credentials.json source path 未検証 |
| **B7** | P3 | dead code (STATE.existing_status) 削除 |
| **B8** | P3 | psql 子プロセスに最小 env のみ渡す |
| **B12** | P3 | renderer-crash dialog の文言精緻化 |
| **B13** | P3 | aria-label 追加 |

## B1 (P0): Mini/Wizard 共存 lock 修正

`Electron.app.requestSingleInstanceLock(additionalData?)` は **lock key 引数ではない**。lock は app.name + userData ディレクトリで決まる。Mini.exe と Setup.exe は **rename copy** で同じ app.name を持ち、同じ userData を共有 → 同じ lock を握る。

**症状**: Mini 起動中に CTA「Setup Wizard を起動」クリック → Setup.exe spawn → lock check fail → `app.quit()` → 何も起きない。

**修正** (`desktop/main.js`):
```js
if (MODE === "wizard") {
  app.setPath("userData", path.join(app.getPath("appData"), "WinServerRAG-Wizard"));
}
const gotLock = app.requestSingleInstanceLock();
```

userData を mode 別に分けることで、各モードが独自 SingletonLock ファイルを持つ。

## B2 (P1): Back during db_init

`wizard.js` の Back ボタンに inflight ガード無し → Step 6 の onNext awaiting 中に Back 押すと stepIdx が変わって、resolving onNext が stale step の DOM を触る。

**修正**: `_busyOnNext` flag、Back と Next 両方が「awaiting 中なら no-op」。

## B3 (P2): log listener leak

`preload-wizard.js` の `onDbInitLog` が `ipcRenderer.on()` を毎回追加 (置換ではない) → 再実行で listener 累積 → 各ログ行が N 回 append される。

**修正**: `onDbInitLog` が `off()` disposer を返し、`onNext` の `finally` で detach。

## B4 (P2): pre-fill 不能

`wizard:read-config` が status しか返さなかった。Step 0 で values を pre-fill できず、wizard 再実行のたびに defaults。

**修正** (`wizard-ipc.js`):
```js
ipcMain.handle("wizard:read-config", () => {
  const status = ctx.configCheck.checkConfig();
  const parsed = ctx.configCheck.readConfig();
  return { ...status, values: (parsed && parsed.values) || {} };
});
```

`wizard.js` Step 0 で `STATE.{google,postgres,indexing,api}` に既存値マージ。

## B5 (P2): Back で入力消失

`collectPg()` 等の collector は onNext でしか呼ばれず、Back では state に保存されない。

**修正**: `snapshotCurrentStep()` を Back と Next 両方の click handler で呼ぶ。

## B6 (P2): credentials.json 検証

`copyCredentials(srcPath)` が source path をそのまま信用 → 任意ファイルを credentials.json にコピーできる経路 (devtools console など)。

**修正**: 拡張子 `.json` / サイズ 32KB 以下 / JSON parse 可能 / `installed` または `web` 直下に `client_id` があることを確認。Google OAuth credentials の実形状にマッチしない場合は reject。

## B8: psql に最小 env

`testPgConnection` が `process.env` 全体を child に展開 → API_BEARER_TOKEN 等が漏れる経路。

**修正**: `SystemRoot` / `PATH` / `TEMP` / `PG*` のみの最小 env。

## Test plan

- [x] All 6 modified JS files pass `node --check`
- [x] `service-control.test.js` (25 cases) + `config-check.test.js` (18 cases) all pass
- [ ] CI lint / Analyze Python / CodeQL pass
- [ ] CI installer build → `WinServerRAG-Daemon-Installer-1.3.0.exe`
- [ ] **B1 検証 (実機)**: Mini Monitor 起動 → CTA ボタンクリック → Setup Wizard ウィンドウが**実際に開く**
- [ ] **B2 検証**: Step 6 で「実行する」→ ログ出始め → Back 連打 → state 崩壊しない
- [ ] **B3 検証**: Step 6 → 戻る → Step 6 → 「再実行」→ ログが二重表示されない
- [ ] **B4 検証**: wizard 完走後再起動 → Step 2/3 のフォームに前回の値が pre-fill されている
- [ ] **B6 検証**: 開発者ツールで `window.wizard.copyCredentials("C:\\Windows\\System32\\drivers\\etc\\hosts")` → reject

🤖 Generated with [Claude Code](https://claude.com/claude-code)
