### PR TITLE
fix(mini,wizard): suppress default Chromium context menu

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -145,6 +145,11 @@ function createMiniWindow() {
   win.on("unresponsive", () => {
     console.warn("[main] renderer unresponsive");
   });
+  // v1.3.3: suppress the default Chromium context menu (right-click /
+  // Context Menu keyboard key). The default has Reload / Save / Print /
+  // Inspect / etc. which look unprofessional on a polished UI window.
+  // The Debug submenu set up below still works via Ctrl+Shift+I.
+  win.webContents.on("context-menu", (e) => e.preventDefault());
   win.setMenuBarVisibility(false);
   // Hidden accelerators: menu is not visible but accelerators still fire.
   // Lets the user pop DevTools / reload / force-refresh when diagnosing the UI.
@@ -193,6 +198,11 @@ function createWizardWindow() {
     } catch {}
     app.exit(3);
   });
+  // v1.3.3: suppress the default Chromium context menu (see Mini window
+  // comment). The Wizard renders form inputs; the default menu's Cut /
+  // Copy / Paste items conflict with the polished step-by-step UX.
+  // Standard keyboard shortcuts (Ctrl+C / Ctrl+V) still work.
+  win.webContents.on("context-menu", (e) => e.preventDefault());
   win.setMenuBarVisibility(false);
   const menu = Menu.buildFromTemplate([{
     label: "Debug", visible: false, submenu: [


### PR DESCRIPTION
右クリックや Context Menu キーで出る Chromium デフォルトのコンテキストメニュー (Reload / Save / Print / Inspect 等) を抑制。

Mini Monitor / Setup Wizard 両ウィンドウで:
```js
win.webContents.on('context-menu', (e) => e.preventDefault());
```

標準ショートカット (Ctrl+C/Ctrl+V/Ctrl+Shift+I 隠し DevTools) は引き続き動作。右クリック / Context Menu キーのポップアップだけ抑制。

Note: もし「Windows キー (Start Menu)」の話だったら Electron からは制御不能 (OS-level keyboard hook が必要、対象外)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)