### PR TITLE
fix(wizard): PG test diagnostic detail + clear stale result on click

### DIFF
--- a/desktop/wizard-ipc.js
+++ b/desktop/wizard-ipc.js
@@ -129,13 +129,36 @@ function testPgConnection(params) {
           // failed for user", "database X does not exist", etc) over Node's
           // generic "Command failed" wrapper. stderr is what the operator
           // needs to fix the problem.
+          //
+          // v1.3.4 fix: when stderr is empty (psql aborted before writing —
+          // typically DLL load failure, ENOENT, or sandbox/permissions),
+          // surface diagnostic fields so the operator (and we) can tell
+          // WHAT went wrong instead of seeing "Command failed: <cmd>" alone.
           const stderrText = String(stderr || "").trim();
-          const errorText = stderrText.length > 0
-            ? stderrText
-            : String((err && err.message) || err);
+          const stdoutText = String(stdout || "").trim();
+          const diag = [];
+          if (err.code !== undefined && err.code !== null) diag.push(`code=${err.code}`);
+          if (err.errno !== undefined && err.errno !== null) diag.push(`errno=${err.errno}`);
+          if (err.signal) diag.push(`signal=${err.signal}`);
+          if (err.killed) diag.push("killed=true (timeout?)");
+          let errorText;
+          if (stderrText) {
+            errorText = stderrText;
+          } else if (stdoutText) {
+            errorText = `(no stderr, stdout=${stdoutText})`;
+          } else {
+            errorText = String((err && err.message) || err);
+          }
+          if (diag.length) errorText += `  [${diag.join(", ")}]`;
+          // Hint: ENOENT means the binary path is wrong — almost always
+          // a "PostgreSQL not installed at expected path" issue.
+          if (err.code === "ENOENT") {
+            errorText += "\n\n(psql.exe が見つかりません。PostgreSQL 17 を C:\\Program Files\\PostgreSQL\\17\\ にインストールしてください)";
+          }
           resolve({
             ok: false,
-            error: errorText.slice(0, 500),
+            error: errorText.slice(0, 800),
+            psqlPath: psql,
           });
           return;
         }

--- a/desktop/wizard.js
+++ b/desktop/wizard.js
@@ -197,6 +197,10 @@ const steps = [
         <div id="pg-test-result"></div>
       `;
       $("pg-test").addEventListener("click", async () => {
+        // v1.3.4: clear previous result the moment the test fires so the
+        // user doesn't see stale "❌ 接続失敗: ..." lingering during the
+        // new test's network roundtrip. Status footer shows progress.
+        $("pg-test-result").innerHTML = `<div class="msg" style="opacity:.7">⏳ 接続テスト中...</div>`;
         setStatus("接続テスト中...", null);
         const params = collectPg();
         const r = await W.testPgConnection(params);
@@ -206,8 +210,9 @@ const steps = [
           box.innerHTML = `<div class="msg ok">✅ 接続成功 (SELECT 1 が通りました)</div>`;
           setStatus("接続 OK", "ok");
         } else {
-          box.innerHTML = `<div class="msg err">❌ 接続失敗: ${escapeHtml(r.error)}</div>`;
-          setStatus("接続失敗", "err");
+          // Use <pre> so multi-line diag (with code=N etc) wraps nicely.
+          box.innerHTML = `<div class="msg err">❌ 接続失敗:<pre style="margin:4px 0 0;white-space:pre-wrap;font-size:11px">${escapeHtml(r.error)}</pre></div>`;
+          setStatus("接続失敗 (テストは informational、「次へ」で進めます)", "err");
         }
       });
       setNext("次へ", true);


### PR DESCRIPTION
ユーザー報告: PG 接続テストが `Command failed: psql.exe -c SELECT 1` で失敗し続ける、stderr 空。なぜ失敗するか分からない。

修正:
1. **エラー診断詳細化**: stderr 空のとき err.code / errno / signal / killed を error メッセージに付加。ENOENT は明示的に「PostgreSQL not installed at expected path」ヒントを出す。psqlPath も返す。
2. **クリック瞬間に過去エラー消去**: 接続テストボタン押した瞬間に `⏳ 接続テスト中...` を表示。スタールな `❌ 失敗` が残らない。
3. **"次へ" 進める旨を明示**: テストは informational、failure でも次に進める旨フッターに表示。

なぜ stderr 空 + 非ゼロ exit になるか不明 (DLL load failure / sandbox / permission issue 候補)。診断情報で次回特定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)